### PR TITLE
add macros (+ .gsh) & local variables to completion & hover

### DIFF
--- a/GSCLSP.Benchmark/GscCompletionHandlerBenchmark.cs
+++ b/GSCLSP.Benchmark/GscCompletionHandlerBenchmark.cs
@@ -21,7 +21,7 @@ public class GscCompletionHandlerBenchmark
     public void Setup()
     {
         _indexer = new GscIndexer();
-        _completionHandler = new GscCompletionHandler(_indexer);
+        _completionHandler = new GscCompletionHandler(_indexer, new GscDocumentStore());
         // Create test workspace
         string tempDir = Path.Combine(Path.GetTempPath(), "gsclsp-completion-" + Guid.NewGuid());
         Directory.CreateDirectory(tempDir);

--- a/GSCLSP.Benchmark/GscHoverHandlerBenchmark.cs
+++ b/GSCLSP.Benchmark/GscHoverHandlerBenchmark.cs
@@ -21,7 +21,7 @@ public class GscHoverHandlerBenchmark
     public void Setup()
     {
         _indexer = new GscIndexer();
-        _hoverHandler = new GscHoverHandler(_indexer);
+        _hoverHandler = new GscHoverHandler(_indexer, new GscDocumentStore());
         // Create test workspace
         string tempDir = Path.Combine(Path.GetTempPath(), "gsclsp-hover-" + Guid.NewGuid());
         Directory.CreateDirectory(tempDir);

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -36,6 +36,10 @@ public partial class GscIndexer
     private static readonly Dictionary<string, List<LocalVariable>> _localVarCache = [];
     private static readonly Lock _localVarCacheLock = new();
 
+    public record MacroDefinition(string Name, string Value, string FilePath, int Line);
+    private static readonly Dictionary<string, List<MacroDefinition>> _macroCache = [];
+    private static readonly Lock _macroCacheLock = new();
+
     public static string NormalizePath(string? path)
     {
         if (string.IsNullOrWhiteSpace(path)) return string.Empty;
@@ -100,6 +104,11 @@ public partial class GscIndexer
             _localVarCache.Clear();
         }
 
+        lock (_macroCacheLock)
+        {
+            _macroCache.Clear();
+        }
+
         Task.Run(() =>
         {
             if (File.Exists(cacheFile))
@@ -155,6 +164,13 @@ public partial class GscIndexer
             if (includeMatch.Success)
             {
                 fileMap.Includes.Add(includeMatch.Groups[1].Value.Replace("\\", "/"));
+                continue;
+            }
+
+            var inlineMatch = InlinePathRegex().Match(line);
+            if (inlineMatch.Success)
+            {
+                fileMap.Inlines.Add(inlineMatch.Groups[1].Value.Replace("\\", "/"));
                 continue;
             }
 
@@ -480,6 +496,144 @@ public partial class GscIndexer
         return [.. variables.Values];
     }
 
+    public static List<MacroDefinition> GetFileMacros(string filePath)
+    {
+        string cacheKey = filePath.Replace("\\", "/").ToLower();
+
+        lock (_macroCacheLock)
+        {
+            if (_macroCache.TryGetValue(cacheKey, out var cached))
+                return cached;
+        }
+
+        var result = ScanFileMacros(filePath);
+
+        lock (_macroCacheLock)
+        {
+            _macroCache[cacheKey] = result;
+        }
+
+        return result;
+    }
+
+    private static List<MacroDefinition> ScanFileMacros(string filePath)
+    {
+        var macros = new List<MacroDefinition>();
+        try
+        {
+            var lines = File.ReadAllLines(filePath);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var trimmed = lines[i].TrimStart();
+                if (!trimmed.StartsWith("#define ")) continue;
+
+                var afterDefine = trimmed[8..];
+                int spaceIdx = afterDefine.IndexOf(' ');
+                int tabIdx = afterDefine.IndexOf('\t');
+
+                string macroName;
+                string macroValue;
+
+                if (spaceIdx < 0 && tabIdx < 0)
+                {
+                    macroName = afterDefine.Trim();
+                    macroValue = "";
+                }
+                else
+                {
+                    int sepIdx = (spaceIdx >= 0 && tabIdx >= 0) ? Math.Min(spaceIdx, tabIdx)
+                               : (spaceIdx >= 0 ? spaceIdx : tabIdx);
+                    macroName = afterDefine[..sepIdx].Trim();
+                    macroValue = afterDefine[(sepIdx + 1)..].Trim();
+                }
+
+                if (!string.IsNullOrEmpty(macroName))
+                {
+                    macros.Add(new MacroDefinition(macroName, macroValue, filePath, i + 1));
+                }
+            }
+        }
+        catch { }
+        return macros;
+    }
+
+    public MacroDefinition? ResolveMacro(string callingFilePath, string macroName)
+    {
+        var localMacros = GetFileMacros(callingFilePath);
+        var found = localMacros.FirstOrDefault(m => m.Name.Equals(macroName, StringComparison.OrdinalIgnoreCase));
+        if (found != null) return found;
+
+        string normalizedPath = callingFilePath.Replace("\\", "/").ToLower();
+        GscFileMap? fileMap = null;
+
+        if (!_workspaceFileMaps.TryGetValue(normalizedPath, out fileMap))
+            _fileMaps.TryGetValue(normalizedPath, out fileMap);
+
+        if (fileMap != null)
+        {
+            foreach (var inlinePath in fileMap.Inlines)
+            {
+                var resolvedPath = ResolveInlinePath(inlinePath);
+                if (resolvedPath == null) continue;
+
+                var inlineMacros = GetFileMacros(resolvedPath);
+                found = inlineMacros.FirstOrDefault(m => m.Name.Equals(macroName, StringComparison.OrdinalIgnoreCase));
+                if (found != null) return found;
+            }
+        }
+
+        return null;
+    }
+
+    public List<MacroDefinition> GetAllVisibleMacros(string callingFilePath)
+    {
+        var result = new List<MacroDefinition>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var m in GetFileMacros(callingFilePath))
+        {
+            if (seen.Add(m.Name)) result.Add(m);
+        }
+
+        string normalizedPath = callingFilePath.Replace("\\", "/").ToLower();
+        GscFileMap? fileMap = null;
+
+        if (!_workspaceFileMaps.TryGetValue(normalizedPath, out fileMap))
+            _fileMaps.TryGetValue(normalizedPath, out fileMap);
+
+        if (fileMap != null)
+        {
+            foreach (var inlinePath in fileMap.Inlines)
+            {
+                var resolvedPath = ResolveInlinePath(inlinePath);
+                if (resolvedPath == null) continue;
+
+                foreach (var m in GetFileMacros(resolvedPath))
+                {
+                    if (seen.Add(m.Name)) result.Add(m);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private string? ResolveInlinePath(string inlinePath)
+    {
+        string normalized = inlinePath.Replace("\\", "/").ToLower();
+        if (!normalized.EndsWith(".gsh")) normalized += ".gsh";
+
+        var match = _workspaceFileMaps.Values.FirstOrDefault(f =>
+            f.FilePath.Replace("\\", "/").ToLower().EndsWith(normalized));
+        if (match != null) return match.FilePath;
+
+        match = _fileMaps.Values.FirstOrDefault(f =>
+            f.FilePath.Replace("\\", "/").ToLower().EndsWith(normalized));
+        if (match != null) return match.FilePath;
+
+        return null;
+    }
+
     public GscResolution ResolveFromLine(string contextPath, string rawLine)
     {
         var parsed = GscLineParser.ExtractCall(rawLine);
@@ -591,6 +745,12 @@ public partial class GscIndexer
             foreach (Match inc in includeMatches)
             {
                 fileMap.Includes.Add(inc.Groups[1].Value.Replace("\\", "/"));
+            }
+
+            var inlineMatches = InlinePathRegex().Matches(content);
+            foreach (Match inl in inlineMatches)
+            {
+                fileMap.Inlines.Add(inl.Groups[1].Value.Replace("\\", "/"));
             }
 
             var matches = FunctionMultiLineRegex().Matches(content);
@@ -752,6 +912,12 @@ public partial class GscIndexer
                     _localVarCache.Remove(key);
             }
 
+            lock (_macroCacheLock)
+            {
+                string macroKey = filePath.Replace("\\", "/").ToLower();
+                _macroCache.Remove(macroKey);
+            }
+
             // Remove old symbols from this file
             updatedSymbols.RemoveAll(s => s.FilePath.Equals(filePath, StringComparison.OrdinalIgnoreCase));
 
@@ -775,6 +941,13 @@ public partial class GscIndexer
                             if (includeMatch.Success)
                             {
                                 fileMap.Includes.Add(includeMatch.Groups[1].Value.Replace("\\", "/"));
+                                continue;
+                            }
+
+                            var inlineMatch = InlinePathRegex().Match(line);
+                            if (inlineMatch.Success)
+                            {
+                                fileMap.Inlines.Add(inlineMatch.Groups[1].Value.Replace("\\", "/"));
                                 continue;
                             }
 

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -32,6 +32,10 @@ public partial class GscIndexer
     private static readonly Dictionary<string, GscSymbol?> _scanFunctionCache = [];
     private static readonly Lock _scanCacheLock = new();
 
+    public record LocalVariable(string Name, string Value, int Line);
+    private static readonly Dictionary<string, List<LocalVariable>> _localVarCache = [];
+    private static readonly Lock _localVarCacheLock = new();
+
     public static string NormalizePath(string? path)
     {
         if (string.IsNullOrWhiteSpace(path)) return string.Empty;
@@ -89,6 +93,11 @@ public partial class GscIndexer
         lock (_scanCacheLock)
         {
             _scanFunctionCache.Clear();
+        }
+
+        lock (_localVarCacheLock)
+        {
+            _localVarCache.Clear();
         }
 
         Task.Run(() =>
@@ -380,6 +389,97 @@ public partial class GscIndexer
         return null;
     }
 
+    public static string? FindEnclosingFunctionName(string[] lines, int cursorLine)
+    {
+        for (int i = cursorLine; i >= 0; i--)
+        {
+            if (lines[i].Length == 0 || char.IsWhiteSpace(lines[i][0])) continue;
+            var match = FunctionMultiLineRegex().Match(lines[i]);
+            if (match.Success) return match.Groups["name"].Value;
+        }
+        return null;
+    }
+
+    public static List<LocalVariable> GetLocalVariables(string filePath, string functionName, string[] lines, int cursorLine)
+    {
+        string cacheKey = $"{filePath}|{functionName}";
+
+        lock (_localVarCacheLock)
+        {
+            if (_localVarCache.TryGetValue(cacheKey, out var cached))
+                return cached;
+        }
+
+        var result = ScanLocalVariablesForFunction(lines, cursorLine);
+
+        lock (_localVarCacheLock)
+        {
+            _localVarCache[cacheKey] = result;
+        }
+
+        return result;
+    }
+
+    private static readonly HashSet<string> _reservedWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "if", "else", "for", "foreach", "while", "switch", "return", "wait",
+        "waittill", "waittillmatch", "waittillframeend", "notify", "endon",
+        "thread", "childthread", "break", "continue", "case", "default",
+        "true", "false", "undefined", "self", "level", "game"
+    };
+
+    private static List<LocalVariable> ScanLocalVariablesForFunction(string[] lines, int cursorLine)
+    {
+        int funcDefLine = -1;
+        for (int i = cursorLine; i >= 0; i--)
+        {
+            if (lines[i].Length > 0 && !char.IsWhiteSpace(lines[i][0]) && FunctionMultiLineRegex().IsMatch(lines[i]))
+            {
+                funcDefLine = i;
+                break;
+            }
+        }
+        if (funcDefLine < 0) return [];
+
+        int braceStart = -1;
+        for (int i = funcDefLine; i < lines.Length; i++)
+        {
+            if (lines[i].Contains('{')) { braceStart = i; break; }
+        }
+        if (braceStart < 0) return [];
+
+        int depth = 0;
+        int funcEnd = lines.Length - 1;
+        for (int i = braceStart; i < lines.Length; i++)
+        {
+            foreach (char c in lines[i])
+            {
+                if (c == '{') depth++;
+                else if (c == '}') depth--;
+            }
+            if (depth == 0) { funcEnd = i; break; }
+        }
+
+        var variables = new Dictionary<string, LocalVariable>(StringComparer.OrdinalIgnoreCase);
+        for (int i = braceStart; i <= funcEnd; i++)
+        {
+            var match = LocalVarAssignmentRegex().Match(lines[i]);
+            if (!match.Success) continue;
+
+            string name = match.Groups[1].Value;
+            string value = match.Groups[2].Value.Trim();
+
+            if (_reservedWords.Contains(name)) continue;
+
+            if (!variables.ContainsKey(name))
+            {
+                variables[name] = new LocalVariable(name, value, i + 1);
+            }
+        }
+
+        return [.. variables.Values];
+    }
+
     public GscResolution ResolveFromLine(string contextPath, string rawLine)
     {
         var parsed = GscLineParser.ExtractCall(rawLine);
@@ -640,6 +740,16 @@ public partial class GscIndexer
 
                 foreach (var key in keysToRemove)
                     _scanFunctionCache.Remove(key);
+            }
+
+            lock (_localVarCacheLock)
+            {
+                var keysToRemove = _localVarCache.Keys
+                    .Where(k => k.StartsWith(filePath + "|", StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                foreach (var key in keysToRemove)
+                    _localVarCache.Remove(key);
             }
 
             // Remove old symbols from this file

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -21,7 +21,7 @@ public partial class GscIndexer
 
     // File watching and caching
     private FileSystemWatcher? _fileWatcher;
-    private string? _workspacePath;
+    public string? WorkspacePath { get; private set; }
     private readonly Dictionary<string, string> _fileContentCache = [];
     private readonly HashSet<string> _pendingChanges = [];
     private readonly Lock _pendingChangesLock = new();
@@ -698,6 +698,11 @@ public partial class GscIndexer
             k.Replace("\\", "/").EndsWith(searchSuffix, StringComparison.OrdinalIgnoreCase));
     }
 
+    public IEnumerable<string> GetAllIndexedFilePaths() =>
+        _workspaceFileMaps.Values.Select(f => f.FilePath)
+            .Concat(_fileMaps.Values.Select(f => f.FilePath))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
     public IEnumerable<GscSymbol> GetSymbolsByName(string name) =>
         _symbols.Where(s => s.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
 
@@ -730,7 +735,7 @@ public partial class GscIndexer
 
         _workspaceFileMaps.Clear();
         _fileContentCache.Clear();
-        _workspacePath = workspacePath;
+        WorkspacePath = workspacePath;
 
         var files = Directory.GetFiles(workspacePath, "*.*", SearchOption.AllDirectories)
             .Where(s => s.EndsWith(".gsc") || s.EndsWith(".gsh"));
@@ -816,14 +821,19 @@ public partial class GscIndexer
         }
     }
 
+    public string[] GetFileLines(string filePath)
+    {
+        return GetFileContent(filePath).Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+    }
+
     private void StartFileWatching()
     {
-        if (string.IsNullOrEmpty(_workspacePath) || _fileWatcher != null)
+        if (string.IsNullOrEmpty(WorkspacePath) || _fileWatcher != null)
             return;
 
         try
         {
-            _fileWatcher = new FileSystemWatcher(_workspacePath)
+            _fileWatcher = new FileSystemWatcher(WorkspacePath)
             {
                 Filter = "*.*",
                 NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
@@ -836,7 +846,7 @@ public partial class GscIndexer
             _fileWatcher.Deleted += OnFileChanged;
             _fileWatcher.Renamed += OnFileRenamed;
 
-            Console.Error.WriteLine($"GSCLSP: File watching started for {_workspacePath}");
+            Console.Error.WriteLine($"GSCLSP: File watching started for {WorkspacePath}");
         }
         catch (Exception ex)
         {

--- a/GSCLSP.Core/Models/GscFileMap.cs
+++ b/GSCLSP.Core/Models/GscFileMap.cs
@@ -4,5 +4,6 @@ public class GscFileMap
 {
     public string FilePath { get; set; } = string.Empty;
     public List<string> Includes { get; set; } = [];
+    public List<string> Inlines { get; set; } = [];
     public List<GscSymbol> LocalSymbols { get; set; } = [];
 }

--- a/GSCLSP.Core/Models/RegexPatterns.cs
+++ b/GSCLSP.Core/Models/RegexPatterns.cs
@@ -37,4 +37,7 @@ public partial class RegexPatterns
 
     [GeneratedRegex(@"(?:(\w+)\s+)?(?:([\w\\]+)::)?(\w+)\s*\((.*)\)", RegexOptions.Compiled)]
     public static partial Regex CallRegex();
+
+    [GeneratedRegex(@"^\s+([a-zA-Z_]\w*)\s*=\s*(.+?)\s*;", RegexOptions.Compiled)]
+    public static partial Regex LocalVarAssignmentRegex();
 }

--- a/GSCLSP.Extension/package.json
+++ b/GSCLSP.Extension/package.json
@@ -17,6 +17,7 @@
   ],
   "keywords": [
     "gsc",
+    "gsh",
     "lsp",
     "cod"
   ],
@@ -33,10 +34,13 @@
         "id": "gsc",
         "aliases": [
           "GSC",
-          "gsc"
+          "gsc",
+          "GSH",
+          "gsh"
         ],
         "extensions": [
-          ".gsc"
+          ".gsc",
+          ".gsh"
         ],
         "configuration": "./language-configuration.json"
       }
@@ -45,6 +49,11 @@
       {
         "language": "gsc",
         "scopeName": "source.gsc",
+        "path": "./syntaxes/gsc.tmLanguage.json"
+      },
+      {
+        "language": "gsh",
+        "scopeName": "source.gsh",
         "path": "./syntaxes/gsc.tmLanguage.json"
       }
     ],

--- a/GSCLSP.Server/Handlers/GscCompletionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionHandler.cs
@@ -4,23 +4,28 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using static GSCLSP.Core.Models.RegexPatterns;
 
 namespace GSCLSP.Server.Handlers
 {
-    public partial class GscCompletionHandler(GscIndexer indexer) : ICompletionHandler
+    public partial class GscCompletionHandler(GscIndexer indexer, GscDocumentStore documentStore) : ICompletionHandler
     {
         private readonly GscIndexer _indexer = indexer;
+        private readonly GscDocumentStore _documentStore = documentStore;
         private readonly ConcurrentDictionary<string, HashSet<string>> _fileIncludesCache = [];
 
         public async Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
         {
+#if DEBUG
+            var sw = Stopwatch.StartNew();
+#endif
+
             var completions = new List<CompletionItem>();
             var uri = request.TextDocument.Uri;
             var currentFilePath = uri.GetFileSystemPath();
 
-            // Use cached content instead of reading from disk
-            var content = _indexer.GetFileContent(currentFilePath);
+            var content = _documentStore.Get(uri) ?? _indexer.GetFileContent(currentFilePath);
             var currentFileLines = content.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
 
             if (request.Position.Line >= currentFileLines.Length) return new CompletionList();
@@ -29,6 +34,118 @@ namespace GSCLSP.Server.Handlers
             // What did the user type before the cursor?
             int safeLength = Math.Min(request.Position.Character, line.Length);
             string lineUntilCursor = line[..safeLength];
+
+            // check # when typing to show directive keywords quick
+            // this will be used to show the completion handler for more stuff later
+            var trimmedLine = lineUntilCursor.TrimStart();
+
+            if (trimmedLine.StartsWith("#") && !trimmedLine.Contains(' '))
+            {
+                int hashPos = lineUntilCursor.IndexOf('#');
+                var directiveRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                    new Position(request.Position.Line, hashPos),
+                    request.Position
+                );
+
+                var directiveMapping = new[] { ("#include", "#include "), ("#using", "#using "), ("#inline", "#inline "), ("#define", "#define ");
+                foreach (var (label, insert) in directiveMapping )
+                {
+                    completions.Add(new CompletionItem
+                    {
+                        Label = label,
+                        Kind = CompletionItemKind.Keyword,
+                        FilterText = label,
+                        InsertTextFormat = InsertTextFormat.PlainText,
+                        TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit { Range = directiveRange, NewText = insert }),
+                        Command = new Command { Name = "editor.action.triggerSuggest" }
+                    });
+                }
+                return new CompletionList(completions);
+            }
+
+            if (trimmedLine.StartsWith("#include ") || trimmedLine.StartsWith("#using ") || trimmedLine.StartsWith("#inline "))
+            {
+                bool isInline = trimmedLine.StartsWith("#inline ");
+                var typed = trimmedLine.Split(' ', 2)[1].TrimEnd(';').Replace("/", "\\");
+
+                var prefix = "";
+                var lastSlash = typed.LastIndexOf('\\');
+                if (lastSlash >= 0) prefix = typed[..(lastSlash + 1)];
+
+                int segmentStart = lineUntilCursor.LastIndexOf('\\') + 1;
+                if (segmentStart == 0) segmentStart = lineUntilCursor.LastIndexOf(' ') + 1;
+                var segmentRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                    new Position(request.Position.Line, segmentStart),
+                    request.Position
+                );
+
+                var roots = new List<string>();
+                if (_indexer.WorkspacePath != null) roots.Add(_indexer.WorkspacePath.Replace("\\", "/").TrimEnd('/'));
+                if (_indexer.DumpPath != null) roots.Add(_indexer.DumpPath.Replace("\\", "/").TrimEnd('/'));
+
+                var folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var filePath in _indexer.GetAllIndexedFilePaths())
+                {
+                    var normalized = filePath.Replace("\\", "/");
+                    var ext = Path.GetExtension(normalized);
+                    bool isGsh = ext.Equals(".gsh", StringComparison.OrdinalIgnoreCase);
+                    bool isGsc = ext.Equals(".gsc", StringComparison.OrdinalIgnoreCase);
+
+                    if (!isGsc && !isGsh) continue;
+                    if (isInline && !isGsh) continue;
+                    if (!isInline && isGsh) continue;
+
+                    var relativePath = normalized;
+                    foreach (var root in roots)
+                    {
+                        if (normalized.StartsWith(root + "/", StringComparison.OrdinalIgnoreCase))
+                        {
+                            relativePath = normalized[(root.Length + 1)..];
+                            break;
+                        }
+                    }
+
+                    var gscPath = relativePath.Replace("/", "\\");
+                    if (!gscPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) continue;
+
+                    var remaining = gscPath[prefix.Length..];
+                    var nextSlash = remaining.IndexOf('\\');
+
+                    if (nextSlash >= 0)
+                    {
+                        var folder = remaining[..nextSlash];
+                        if (folders.Add(folder))
+                        {
+                            completions.Add(new CompletionItem
+                            {
+                                Label = folder,
+                                LabelDetails = new CompletionItemLabelDetails { Description = "(folder)" },
+                                Kind = CompletionItemKind.Folder,
+                                FilterText = folder,
+                                InsertTextFormat = InsertTextFormat.PlainText,
+                                TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit { Range = segmentRange, NewText = folder + "\\" }),
+                                Command = new Command { Name = "editor.action.triggerSuggest" }
+                            });
+                        }
+                    }
+                    else
+                    {
+                        var fileName = isGsh ? remaining : remaining[..^4]; // strip .gsc
+                        completions.Add(new CompletionItem
+                        {
+                            Label = fileName,
+                            LabelDetails = new CompletionItemLabelDetails { Description = isGsh ? ".gsh" : ".gsc" },
+                            Kind = CompletionItemKind.File,
+                            FilterText = fileName,
+                            InsertTextFormat = InsertTextFormat.PlainText,
+                            TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit { Range = segmentRange, NewText = fileName })
+                        });
+                    }
+                }
+
+                return FilteredList(completions);
+            }
 
             var namespaceMatch = NameSpaceRegex().Match(lineUntilCursor);
             if (namespaceMatch.Success)
@@ -117,6 +234,11 @@ namespace GSCLSP.Server.Handlers
                     });
                 }
             }
+
+#if DEBUG
+            sw.Stop();
+            Console.Error.WriteLine($"GSCLSP: GscCompletionHandler completed in {sw.Elapsed.TotalMilliseconds:N2}ms");
+#endif
 
             return FilteredList(completions);
         }
@@ -208,7 +330,7 @@ namespace GSCLSP.Server.Handlers
             return new CompletionRegistrationOptions
             {
                 DocumentSelector = TextDocumentSelector.ForLanguage("gsc"),
-                TriggerCharacters = new Container<string>(":", ".")
+                TriggerCharacters = new Container<string>(":", ".", "#", "\\")
             };
         }
     }

--- a/GSCLSP.Server/Handlers/GscCompletionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionHandler.cs
@@ -76,6 +76,25 @@ namespace GSCLSP.Server.Handlers
                 completions.Add(CreateSymbolCompletion(builtIn, CompletionItemKind.Function, "Engine Built-in"));
             }
 
+            var macros = _indexer.GetAllVisibleMacros(currentFilePath);
+            foreach (var macro in macros)
+            {
+                var macroDetail = string.IsNullOrEmpty(macro.Value) ? "" : $" {macro.Value}";
+                completions.Add(new CompletionItem
+                {
+                    Label = macro.Name,
+                    LabelDetails = new CompletionItemLabelDetails
+                    {
+                        Detail = macroDetail,
+                        Description = "Macro"
+                    },
+                    Kind = CompletionItemKind.Constant,
+                    InsertText = macro.Name,
+                    InsertTextFormat = InsertTextFormat.PlainText,
+                    FilterText = macro.Name
+                });
+            }
+
             // Local variables in the enclosing function
             var funcName = GscIndexer.FindEnclosingFunctionName(currentFileLines, request.Position.Line);
             if (funcName != null)

--- a/GSCLSP.Server/Handlers/GscCompletionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionHandler.cs
@@ -47,7 +47,7 @@ namespace GSCLSP.Server.Handlers
                     request.Position
                 );
 
-                var directiveMapping = new[] { ("#include", "#include "), ("#using", "#using "), ("#inline", "#inline "), ("#define", "#define ");
+                var directiveMapping = new[] { ("#include", "#include "), ("#using", "#using "), ("#inline", "#inline "), ("#define", "#define ") };
                 foreach (var (label, insert) in directiveMapping )
                 {
                     completions.Add(new CompletionItem

--- a/GSCLSP.Server/Handlers/GscCompletionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionHandler.cs
@@ -76,6 +76,29 @@ namespace GSCLSP.Server.Handlers
                 completions.Add(CreateSymbolCompletion(builtIn, CompletionItemKind.Function, "Engine Built-in"));
             }
 
+            // Local variables in the enclosing function
+            var funcName = GscIndexer.FindEnclosingFunctionName(currentFileLines, request.Position.Line);
+            if (funcName != null)
+            {
+                var locals = GscIndexer.GetLocalVariables(currentFilePath, funcName, currentFileLines, request.Position.Line);
+                foreach (var localVar in locals)
+                {
+                    completions.Add(new CompletionItem
+                    {
+                        Label = localVar.Name,
+                        LabelDetails = new CompletionItemLabelDetails
+                        {
+                            Detail = $" = {localVar.Value}",
+                            Description = "Local Variable"
+                        },
+                        Kind = CompletionItemKind.Variable,
+                        InsertText = localVar.Name,
+                        InsertTextFormat = InsertTextFormat.PlainText,
+                        FilterText = localVar.Name
+                    });
+                }
+            }
+
             return FilteredList(completions);
         }
 

--- a/GSCLSP.Server/Handlers/GscDefinitionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDefinitionHandler.cs
@@ -54,6 +54,39 @@ public class GscDefinitionHandler(GscIndexer indexer, ILanguageServerConfigurati
         string identifier = GscWordScanner.GetFullIdentifierAt(line, request.Position.Character);
         if (string.IsNullOrEmpty(identifier)) return new DefinitionResult();
 
+        var macro = _indexer.ResolveMacro(currentFilePath, identifier);
+        if (macro != null)
+        {
+            int targetLine = macro.Line - 1;
+            return new DefinitionResult(new Location
+            {
+                Uri = DocumentUri.FromFileSystemPath(macro.FilePath),
+                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                    new Position(targetLine, 0),
+                    new Position(targetLine, 0)
+                )
+            });
+        }
+
+        var funcName = GscIndexer.FindEnclosingFunctionName(lines, request.Position.Line);
+        if (funcName != null)
+        {
+            var locals = GscIndexer.GetLocalVariables(currentFilePath, funcName, lines, request.Position.Line);
+            var localVar = locals.FirstOrDefault(v => v.Name.Equals(identifier, StringComparison.OrdinalIgnoreCase));
+            if (localVar != null)
+            {
+                int targetLine = localVar.Line - 1;
+                return new DefinitionResult(new Location
+                {
+                    Uri = uri,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                        new Position(targetLine, 0),
+                        new Position(targetLine, lines[targetLine].Length)
+                    )
+                });
+            }
+        }
+
         string lookupName = identifier;
         string? pathFilter = null;
 

--- a/GSCLSP.Server/Handlers/GscDocumentSyncHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDocumentSyncHandler.cs
@@ -1,0 +1,61 @@
+using MediatR;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
+using System.Collections.Concurrent;
+
+namespace GSCLSP.Server.Handlers;
+
+public class GscDocumentStore
+{
+    private readonly ConcurrentDictionary<DocumentUri, string> _documents = new();
+
+    public void Update(DocumentUri uri, string text) => _documents[uri] = text;
+    public void Remove(DocumentUri uri) => _documents.TryRemove(uri, out _);
+    public string? Get(DocumentUri uri) => _documents.TryGetValue(uri, out var text) ? text : null;
+}
+
+public class GscDocumentSyncHandler(GscDocumentStore store) : TextDocumentSyncHandlerBase
+{
+    private readonly GscDocumentStore _store = store;
+
+    public override TextDocumentAttributes GetTextDocumentAttributes(DocumentUri uri) =>
+        new(uri, "gsc");
+
+    public override Task<Unit> Handle(DidOpenTextDocumentParams request, CancellationToken cancellationToken)
+    {
+        _store.Update(request.TextDocument.Uri, request.TextDocument.Text);
+        return Unit.Task;
+    }
+
+    public override Task<Unit> Handle(DidChangeTextDocumentParams request, CancellationToken cancellationToken)
+    {
+        foreach (var change in request.ContentChanges)
+        {
+            if (change.Range == null)
+                _store.Update(request.TextDocument.Uri, change.Text);
+        }
+        return Unit.Task;
+    }
+
+    public override Task<Unit> Handle(DidCloseTextDocumentParams request, CancellationToken cancellationToken)
+    {
+        _store.Remove(request.TextDocument.Uri);
+        return Unit.Task;
+    }
+
+    public override Task<Unit> Handle(DidSaveTextDocumentParams request, CancellationToken cancellationToken) =>
+        Unit.Task;
+
+    protected override TextDocumentSyncRegistrationOptions CreateRegistrationOptions(TextSynchronizationCapability capability, ClientCapabilities clientCapabilities)
+    {
+        return new TextDocumentSyncRegistrationOptions
+        {
+            DocumentSelector = TextDocumentSelector.ForLanguage("gsc", "gsh"),
+            Change = TextDocumentSyncKind.Full,
+            Save = new SaveOptions { IncludeText = false }
+        };
+    }
+}

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -52,7 +52,7 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
         if (identifier.StartsWith("::")) identifier = identifier[2..];
         if (string.IsNullOrEmpty(identifier)) return null;
 
-        var macroHover = FindMacroDefinition(lines, identifier, request.Position.Line);
+        var macroHover = FindMacroDefinition(filePath, identifier);
         if (macroHover != null) return macroHover;
 
         var localVarHover = FindLocalVariable(filePath, lines, identifier, request.Position.Line);
@@ -120,45 +120,19 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
         return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
     }
 
-    private static Hover? FindMacroDefinition(string[] lines, string identifier, int hoverLine)
+    private Hover? FindMacroDefinition(string filePath, string identifier)
     {
-        for (int i = 0; i < lines.Length; i++)
-        {
-            var trimmed = lines[i].TrimStart();
-            if (!trimmed.StartsWith("#define ")) continue;
+        var macro = _indexer.ResolveMacro(filePath, identifier);
+        if (macro == null) return null;
 
-            var afterDefine = trimmed[8..]; // skip "#define "
-            int spaceIdx = afterDefine.IndexOf(' ');
-            int tabIdx = afterDefine.IndexOf('\t');
+        var contentValue = $"```gsc\n#define {macro.Name}";
+        if (!string.IsNullOrEmpty(macro.Value))
+            contentValue += $" {macro.Value}";
+        contentValue += "\n```\n---\n";
+        contentValue += $"**Defined in:** `{macro.FilePath}`\n\n";
+        contentValue += $"**Line:** {macro.Line}";
 
-            string macroName;
-            string macroValue;
-
-            if (spaceIdx < 0 && tabIdx < 0)
-            {
-                macroName = afterDefine.Trim();
-                macroValue = "";
-            }
-            else
-            {
-                int sepIdx = (spaceIdx >= 0 && tabIdx >= 0) ? Math.Min(spaceIdx, tabIdx)
-                           : (spaceIdx >= 0 ? spaceIdx : tabIdx);
-                macroName = afterDefine[..sepIdx].Trim();
-                macroValue = afterDefine[(sepIdx + 1)..].Trim();
-            }
-
-            if (!macroName.Equals(identifier, StringComparison.OrdinalIgnoreCase)) continue;
-
-            var contentValue = $"```gsc\n#define {macroName}";
-            if (!string.IsNullOrEmpty(macroValue))
-                contentValue += $" {macroValue}";
-            contentValue += "\n```\n---\n";
-            contentValue += $"**Line:** {i + 1}";
-
-            var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
-            return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
-        }
-
-        return null;
+        var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
+        return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
     }
 }

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -39,13 +39,16 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
 
         if (line.Trim().StartsWith("#include") || line.Trim().StartsWith("#using") || line.Trim().StartsWith("#inline"))
         {
-            string includedFile = GscWordScanner.GetFullIdentifierAt(line, request.Position.Character);
+            var parts = line.Trim().Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2) return null;
+
+            var directive = parts[0];
+            string includedFile = parts[1].Trim().TrimEnd(';');
             if (string.IsNullOrEmpty(includedFile)) return null;
 
             var foundIncludePath = await _indexer.GetIncludePath(includedFile);
             if (foundIncludePath == null) return null;
 
-            var directive = line.Trim().Split(' ', 2)[0];
             var contentValue = $"### {directive}\n`{foundIncludePath}`";
             var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
             return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -119,11 +119,48 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
         var localVar = locals.FirstOrDefault(v => v.Name.Equals(identifier, StringComparison.OrdinalIgnoreCase));
         if (localVar == null) return null;
 
-        var contentValue = $"```gsc\n{localVar.Name} = {localVar.Value}\n```\n---\n";
-        contentValue += $"**Line:** {localVar.Line}";
+        var comment = GetLeadingComment(lines, localVar.Line - 1);
+
+        var contentValue = $"```gsc\n{localVar.Name} = {localVar.Value}\n```\n";
+        if (!string.IsNullOrEmpty(comment))
+            contentValue += $"{comment}\n\n";
+        contentValue += $"---\n**Line:** {localVar.Line}";
 
         var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
         return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
+    }
+
+    private static string? GetLeadingComment(string[] lines, int lineIndex)
+    {
+        if (lineIndex <= 0 || string.IsNullOrWhiteSpace(lines[lineIndex - 1].Trim()))
+            return null;
+
+        List<string> commentLines = [];
+        bool inBlockComment = false;
+
+        for (int i = lineIndex - 1; i >= 0; i--)
+        {
+            string prevLine = lines[i].Trim();
+
+            if (prevLine.EndsWith("*/")) { inBlockComment = true; prevLine = prevLine.Replace("*/", ""); }
+            if (prevLine.StartsWith("/*"))
+            {
+                string clean = prevLine.TrimStart('/', '*', ' ').Trim();
+                if (!string.IsNullOrWhiteSpace(clean))
+                    commentLines.Insert(0, clean);
+                break;
+            }
+
+            if (inBlockComment || prevLine.StartsWith("//"))
+            {
+                string clean = prevLine.TrimStart('/', '*', ' ').Trim();
+                if (!string.IsNullOrWhiteSpace(clean))
+                    commentLines.Insert(0, clean);
+            }
+            else break;
+        }
+
+        return commentLines.Count > 0 ? string.Join("  \n", commentLines) : null;
     }
 
     private Hover? FindMacroDefinition(string filePath, string identifier)
@@ -131,11 +168,16 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
         var macro = _indexer.ResolveMacro(filePath, identifier);
         if (macro == null) return null;
 
+        string[] macroFileLines = File.ReadAllLines(macro.FilePath);
+        var comment = GetLeadingComment(macroFileLines, macro.Line - 1);
+
         var contentValue = $"```gsc\n#define {macro.Name}";
         if (!string.IsNullOrEmpty(macro.Value))
             contentValue += $" {macro.Value}";
-        contentValue += "\n```\n---\n";
-        contentValue += $"**Defined in:** `{macro.FilePath}`\n\n";
+        contentValue += "\n```\n";
+        if (!string.IsNullOrEmpty(comment))
+            contentValue += $"{comment}\n\n";
+        contentValue += $"---\n**Defined in:** `{macro.FilePath}`\n\n";
         contentValue += $"**Line:** {macro.Line}";
 
         var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -52,6 +52,12 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
         if (identifier.StartsWith("::")) identifier = identifier[2..];
         if (string.IsNullOrEmpty(identifier)) return null;
 
+        var macroHover = FindMacroDefinition(lines, identifier, request.Position.Line);
+        if (macroHover != null) return macroHover;
+
+        var localVarHover = FindLocalVariable(filePath, lines, identifier, request.Position.Line);
+        if (localVarHover != null) return localVarHover;
+
         var resolution = _indexer.ResolveFunction(filePath, identifier);
 
         if (resolution.Symbol != null)
@@ -90,6 +96,64 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
                 contentValue += $"**Defined in:** `{symbol.FilePath}`\n\n" +
                              $"**Line:** {symbol.LineNumber}";
             }
+
+            var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
+            return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
+        }
+
+        return null;
+    }
+
+    private static Hover? FindLocalVariable(string filePath, string[] lines, string identifier, int hoverLine)
+    {
+        var funcName = GscIndexer.FindEnclosingFunctionName(lines, hoverLine);
+        if (funcName == null) return null;
+
+        var locals = GscIndexer.GetLocalVariables(filePath, funcName, lines, hoverLine);
+        var localVar = locals.FirstOrDefault(v => v.Name.Equals(identifier, StringComparison.OrdinalIgnoreCase));
+        if (localVar == null) return null;
+
+        var contentValue = $"```gsc\n{localVar.Name} = {localVar.Value}\n```\n---\n";
+        contentValue += $"**Line:** {localVar.Line}";
+
+        var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
+        return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
+    }
+
+    private static Hover? FindMacroDefinition(string[] lines, string identifier, int hoverLine)
+    {
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var trimmed = lines[i].TrimStart();
+            if (!trimmed.StartsWith("#define ")) continue;
+
+            var afterDefine = trimmed[8..]; // skip "#define "
+            int spaceIdx = afterDefine.IndexOf(' ');
+            int tabIdx = afterDefine.IndexOf('\t');
+
+            string macroName;
+            string macroValue;
+
+            if (spaceIdx < 0 && tabIdx < 0)
+            {
+                macroName = afterDefine.Trim();
+                macroValue = "";
+            }
+            else
+            {
+                int sepIdx = (spaceIdx >= 0 && tabIdx >= 0) ? Math.Min(spaceIdx, tabIdx)
+                           : (spaceIdx >= 0 ? spaceIdx : tabIdx);
+                macroName = afterDefine[..sepIdx].Trim();
+                macroValue = afterDefine[(sepIdx + 1)..].Trim();
+            }
+
+            if (!macroName.Equals(identifier, StringComparison.OrdinalIgnoreCase)) continue;
+
+            var contentValue = $"```gsc\n#define {macroName}";
+            if (!string.IsNullOrEmpty(macroValue))
+                contentValue += $" {macroValue}";
+            contentValue += "\n```\n---\n";
+            contentValue += $"**Line:** {i + 1}";
 
             var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
             return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -32,7 +32,9 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
         bool inBlockComment = false;
         for (int l = 0; l < request.Position.Line; l++)
             GscHandlerCommon.GetCodeRanges(lines[l], ref inBlockComment);
+
         var codeRanges = GscHandlerCommon.GetCodeRanges(line, ref inBlockComment);
+
         if (!GscHandlerCommon.IsInCode(codeRanges, request.Position.Character)) return null;
 
         if (line.Trim().StartsWith("#include") || line.Trim().StartsWith("#using") || line.Trim().StartsWith("#inline"))
@@ -43,7 +45,8 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
             var foundIncludePath = await _indexer.GetIncludePath(includedFile);
             if (foundIncludePath == null) return null;
 
-            var contentValue = $"### #Include\n`{foundIncludePath}`";
+            var directive = line.Trim().Split(' ', 2)[0];
+            var contentValue = $"### {directive}\n`{foundIncludePath}`";
             var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
             return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
         }

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -7,9 +7,10 @@ using static GSCLSP.Core.Models.RegexPatterns;
 
 namespace GSCLSP.Server.Handlers;
 
-public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
+public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore documentStore) : IHoverHandler
 {
     private readonly GscIndexer _indexer = indexer;
+    private readonly GscDocumentStore _documentStore = documentStore;
 
     public HoverRegistrationOptions GetRegistrationOptions(HoverCapability capability, ClientCapabilities clientCapabilities)
     {
@@ -24,8 +25,9 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
         var uri = request.TextDocument.Uri;
         var filePath = uri.GetFileSystemPath();
 
-        var lines = await File.ReadAllLinesAsync(filePath, cancellationToken);
-        if (lines == null || request.Position.Line >= lines.Length) return null;
+        var content = _documentStore.Get(uri) ?? _indexer.GetFileContent(filePath);
+        var lines = content.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+        if (request.Position.Line >= lines.Length) return null;
 
         var line = lines[request.Position.Line];
 
@@ -50,8 +52,8 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
             if (foundIncludePath == null) return null;
 
             var contentValue = $"### {directive}\n`{foundIncludePath}`";
-            var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
-            return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
+            var markupContent = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
+            return new Hover { Contents = new MarkedStringsOrMarkupContent(markupContent) };
         }
 
         string identifier = GscWordScanner.GetFullIdentifierAt(line, request.Position.Character).Trim();
@@ -103,8 +105,8 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
                              $"**Line:** {symbol.LineNumber}";
             }
 
-            var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
-            return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
+            var markupContent = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
+            return new Hover { Contents = new MarkedStringsOrMarkupContent(markupContent) };
         }
 
         return null;
@@ -126,8 +128,8 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
             contentValue += $"{comment}\n\n";
         contentValue += $"---\n**Line:** {localVar.Line}";
 
-        var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
-        return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
+        var markupContent = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
+        return new Hover { Contents = new MarkedStringsOrMarkupContent(markupContent) };
     }
 
     private static string? GetLeadingComment(string[] lines, int lineIndex)
@@ -168,7 +170,7 @@ public partial class GscHoverHandler(GscIndexer indexer) : IHoverHandler
         var macro = _indexer.ResolveMacro(filePath, identifier);
         if (macro == null) return null;
 
-        string[] macroFileLines = File.ReadAllLines(macro.FilePath);
+        string[] macroFileLines = _indexer.GetFileLines(macro.FilePath);
         var comment = GetLeadingComment(macroFileLines, macro.Line - 1);
 
         var contentValue = $"```gsc\n#define {macro.Name}";

--- a/GSCLSP.Server/Program.cs
+++ b/GSCLSP.Server/Program.cs
@@ -7,6 +7,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 using OmniSharp.Extensions.LanguageServer.Server;
 
 var indexer = new GscIndexer();
+var documentStore = new GscDocumentStore();
 
 string basePath = AppDomain.CurrentDomain.BaseDirectory;
 string builtInPath = Path.Combine(basePath, "data", "iw4_builtins.json");
@@ -34,7 +35,9 @@ var server = await LanguageServer.From(options =>
         .WithServices(services =>
         {
             services.AddSingleton(indexer);
+            services.AddSingleton(documentStore);
         })
+        .WithHandler<GscDocumentSyncHandler>()
         .WithHandler<GscDefinitionHandler>()
         .WithHandler<GscHoverHandler>()
         .WithHandler<GscCompletionHandler>()


### PR DESCRIPTION
closes #3 #4 #10 

- adds macros with #inline support for current file *(defined in file & external .gsh)* and local variables per function to auto complete, hover, and definition provider
- utilizes the caching of file-specific stuff like done already
- show keyword in embed for `#inline` and `#using`
- improve completion handler for macros and file paths