### PR TITLE
chore: move dumpPath to a config setting instead for multi-workspace support

### DIFF
--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -26,6 +26,7 @@ public partial class GscIndexer
     private readonly HashSet<string> _pendingChanges = [];
     private readonly Lock _pendingChangesLock = new();
     private System.Timers.Timer? _debounceTimer;
+    private System.Timers.Timer? _configDebounceTimer;
     private const int DEBOUNCE_MS = 300;
 
     // Memoization cache for ScanFileForFunction
@@ -39,6 +40,8 @@ public partial class GscIndexer
     public record MacroDefinition(string Name, string Value, string FilePath, int Line);
     private static readonly Dictionary<string, List<MacroDefinition>> _macroCache = [];
     private static readonly Lock _macroCacheLock = new();
+
+    private string? _settingDumpPath;
 
     public static string NormalizePath(string? path)
     {
@@ -87,7 +90,30 @@ public partial class GscIndexer
 
     public void UpdateDumpPath(string? newPath)
     {
-        if (string.IsNullOrWhiteSpace(newPath) || !Directory.Exists(newPath)) return;
+        if (string.IsNullOrWhiteSpace(newPath) || !Directory.Exists(newPath))
+        {
+            DumpPath = null;
+            _symbols.Clear();
+            _fileMaps.Clear();
+
+            lock (_scanCacheLock)
+            {
+                _scanFunctionCache.Clear();
+            }
+
+            lock (_localVarCacheLock)
+            {
+                _localVarCache.Clear();
+            }
+
+            lock (_macroCacheLock)
+            {
+                _macroCache.Clear();
+            }
+
+            return;
+        }
+
         string cacheFile = Path.Combine(newPath, "symbols.json");
 
         DumpPath = newPath;
@@ -757,6 +783,82 @@ public partial class GscIndexer
         });
     }
 
+    public void UpdateSettingDumpPath(string? settingDumpPath)
+    {
+        _settingDumpPath = settingDumpPath;
+        ApplyConfiguredDumpPath();
+    }
+
+    private void ApplyConfiguredDumpPath()
+    {
+        var (hasWorkspaceConfig, workspaceDumpPath) = TryReadWorkspaceDumpPath(WorkspacePath);
+        var resolvedDumpPath = ResolveDumpPathValue(_settingDumpPath, WorkspacePath, hasWorkspaceConfig, workspaceDumpPath);
+
+        if (hasWorkspaceConfig)
+        {
+            if (string.IsNullOrWhiteSpace(workspaceDumpPath))
+                Console.Error.WriteLine("GSCLSP: gsclsp.config.json found with no dumpPath. Clearing dump index.");
+            else
+                Console.Error.WriteLine($"GSCLSP: dumpPath from gsclsp.config.json -> {workspaceDumpPath}");
+        }
+        else
+        {
+            Console.Error.WriteLine("GSCLSP: gsclsp.config.json not found. Dump index disabled unless configured.");
+        }
+
+        UpdateDumpPath(resolvedDumpPath);
+    }
+
+    private static string? ResolveDumpPathValue(string? settingDumpPath, string? workspacePath, bool hasWorkspaceConfig, string? workspaceDumpPath)
+    {
+        var candidate = hasWorkspaceConfig ? workspaceDumpPath : settingDumpPath;
+
+        if (string.IsNullOrWhiteSpace(candidate))
+            return null;
+
+        var clean = candidate.Trim();
+        if (Uri.TryCreate(clean, UriKind.Absolute, out var uri) && uri.IsFile)
+            clean = uri.LocalPath;
+
+        if (!Path.IsPathRooted(clean) && !string.IsNullOrEmpty(workspacePath))
+            clean = Path.GetFullPath(Path.Combine(workspacePath, clean));
+
+        return clean;
+    }
+
+    private static (bool HasConfigFile, string? DumpPath) TryReadWorkspaceDumpPath(string? workspacePath)
+    {
+        if (string.IsNullOrWhiteSpace(workspacePath) || !Directory.Exists(workspacePath))
+            return (false, null);
+
+        var configPath = Path.Combine(workspacePath, "gsclsp.config.json");
+        if (!File.Exists(configPath))
+            return (false, null);
+
+        return (true, ReadDumpPathFromFile(configPath));
+    }
+
+    private static string? ReadDumpPathFromFile(string filePath)
+    {
+        if (!File.Exists(filePath))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(filePath));
+            var root = doc.RootElement;
+
+            if (root.ValueKind != JsonValueKind.Object)
+                return null;
+
+            if (root.TryGetProperty("dumpPath", out var directDumpPath) && directDumpPath.ValueKind == JsonValueKind.String)
+                return directDumpPath.GetString();
+        }
+        catch { }
+
+        return null;
+    }
+
     public void IndexWorkspace(string workspacePath)
     {
         Console.Error.WriteLine($"Indexing Workspace {workspacePath}");
@@ -811,7 +913,8 @@ public partial class GscIndexer
         WorkspaceSymbols = localSymbols;
 
         StartFileWatching();
-        
+        ApplyConfiguredDumpPath();
+
         PreWarmScanCache(localSymbols);
     }
 
@@ -885,8 +988,39 @@ public partial class GscIndexer
         }
     }
 
+    private static bool IsWorkspaceConfigFile(string fullPath) =>
+        Path.GetFileName(fullPath).Equals("gsclsp.config.json", StringComparison.OrdinalIgnoreCase);
+
+    private void ScheduleConfigReload()
+    {
+        _configDebounceTimer?.Stop();
+        _configDebounceTimer?.Dispose();
+
+        _configDebounceTimer = new System.Timers.Timer(DEBOUNCE_MS)
+        {
+            AutoReset = false,
+        };
+
+        _configDebounceTimer.Elapsed += (_, _) =>
+        {
+            try
+            {
+                ApplyConfiguredDumpPath();
+            }
+            catch { }
+        };
+
+        _configDebounceTimer.Start();
+    }
+
     private void OnFileChanged(object sender, FileSystemEventArgs e)
     {
+        if (IsWorkspaceConfigFile(e.FullPath))
+        {
+            ScheduleConfigReload();
+            return;
+        }
+
         if (!e.FullPath.EndsWith(".gsc", StringComparison.OrdinalIgnoreCase) &&
             !e.FullPath.EndsWith(".gsh", StringComparison.OrdinalIgnoreCase))
             return;
@@ -905,6 +1039,11 @@ public partial class GscIndexer
 
     private void OnFileRenamed(object sender, RenamedEventArgs e)
     {
+        if (IsWorkspaceConfigFile(e.OldFullPath) || IsWorkspaceConfigFile(e.FullPath))
+        {
+            ScheduleConfigReload();
+        }
+
         // Invalidate cache for renamed file
         _fileContentCache.Remove(e.OldFullPath);
         OnFileChanged(sender, new FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(e.FullPath)!, Path.GetFileName(e.FullPath)));

--- a/GSCLSP.Extension/package.json
+++ b/GSCLSP.Extension/package.json
@@ -51,18 +51,7 @@
         "scopeName": "source.gsc",
         "path": "./syntaxes/gsc.tmLanguage.json"
       }
-    ],
-    "configuration": {
-      "type": "object",
-      "title": "GSC Intelligence",
-      "properties": {
-        "gsclsp.dumpPath": {
-          "type": "string",
-          "default": "",
-          "description": "Path to your MW2 Game Dump folder for navigation."
-        }
-      }
-    }
+    ]
   },
   "scripts": {
     "build": "bun run build.ts",

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import * as fs from "fs/promises";
 
 import {
   type ExtensionContext,
@@ -8,6 +9,7 @@ import {
   commands,
   ProgressLocation,
   ExtensionMode,
+  type WorkspaceFolder,
 } from "vscode";
 import {
   LanguageClient,
@@ -18,7 +20,33 @@ import {
 
 let client: LanguageClient;
 
+async function ensureWorkspaceConfigFile(folder: WorkspaceFolder): Promise<void> {
+  if (folder.uri.scheme !== "file") {
+    return;
+  }
+
+  const configPath = path.join(folder.uri.fsPath, "gsclsp.config.json");
+
+  try {
+    await fs.access(configPath);
+  } catch {
+    await fs.writeFile(configPath, "{}\n", "utf8");
+  }
+}
+
 export async function activate(context: ExtensionContext): Promise<void> {
+  for (const folder of workspace.workspaceFolders ?? []) {
+    await ensureWorkspaceConfigFile(folder);
+  }
+
+  context.subscriptions.push(
+    workspace.onDidChangeWorkspaceFolders(async (event) => {
+      for (const folder of event.added) {
+        await ensureWorkspaceConfigFile(folder);
+      }
+    }),
+  );
+
   let browseCommand = commands.registerCommand(
     "gsclsp.browseDumpPath",
     async () => {
@@ -41,12 +69,57 @@ export async function activate(context: ExtensionContext): Promise<void> {
           async (progress) => {
             progress.report({ message: "Re-indexing dump..." });
 
-            await workspace
-              .getConfiguration("gsclsp")
-              .update("dumpPath", newPath, true);
-            await client.sendNotification("custom/updateDumpPath", {
-              path: newPath,
-            });
+            const activeUri = window.activeTextEditor?.document.uri;
+            const targetWorkspace = activeUri
+              ? workspace.getWorkspaceFolder(activeUri)
+              : workspace.workspaceFolders?.[0];
+
+            if (!targetWorkspace || targetWorkspace.uri.scheme !== "file") {
+              window.showErrorMessage(
+                "GSCLSP: Open a local workspace folder to save gsclsp.config.json",
+              );
+              return;
+            }
+
+            const configPath = path.join(
+              targetWorkspace.uri.fsPath,
+              "gsclsp.config.json",
+            );
+
+            try {
+              let config: { dumpPath?: string } = {};
+
+              try {
+                const existing = await fs.readFile(configPath, "utf8");
+                const parsed = JSON.parse(existing) as unknown;
+                if (parsed && typeof parsed === "object") {
+                  config = parsed as { dumpPath?: string };
+                }
+              } catch {
+                config = {};
+              }
+
+              config.dumpPath = newPath;
+              await fs.writeFile(
+                configPath,
+                JSON.stringify(config, null, 2),
+                "utf8",
+              );
+
+              await client.sendNotification("custom/updateDumpPath", {
+                path: newPath,
+              });
+
+              window.showInformationMessage(
+                `GSCLSP: Updated ${configPath}`,
+              );
+            } catch (error) {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              window.showErrorMessage(
+                `GSCLSP: Failed to write gsclsp.config.json: ${message}`,
+              );
+            }
 
             return new Promise((resolve) => setTimeout(resolve, 2000));
           },
@@ -95,7 +168,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
     outputChannel,
     synchronize: {
       fileEvents: workspace.createFileSystemWatcher("**/*.gsc"),
-      configurationSection: "gsclsp",
     },
   };
 

--- a/GSCLSP.Server/Handlers/GscCompletionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionHandler.cs
@@ -171,6 +171,11 @@ namespace GSCLSP.Server.Handlers
                     isThisFile ? "Local Function" : "Project Function"));
             }
 
+            foreach (var symbol in _indexer.Symbols)
+            {
+                completions.Add(CreateSymbolCompletion(symbol, CompletionItemKind.Method, "Dump Function"));
+            }
+
             var includesSet = _fileIncludesCache.GetOrAdd(currentFilePath, _ => ParseIncludes(currentFileLines));
 
             if (includesSet.Count > 0)

--- a/GSCLSP.Server/Handlers/GscDefinitionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDefinitionHandler.cs
@@ -29,7 +29,7 @@ public class GscDefinitionHandler(GscIndexer indexer, GscDocumentStore documentS
     {
         var uri = request.TextDocument.Uri;
         var currentFilePath = uri.GetFileSystemPath();
-        var userDumpPath = _configuration?.GetValue<string>("gsclsp:dumpPath");
+        var userDumpPath = _indexer.DumpPath;
 
         var content = _documentStore.Get(uri) ?? _indexer.GetFileContent(currentFilePath);
         if (string.IsNullOrEmpty(content)) return new DefinitionResult();

--- a/GSCLSP.Server/Handlers/GscReferencesHandler.cs
+++ b/GSCLSP.Server/Handlers/GscReferencesHandler.cs
@@ -43,7 +43,7 @@ namespace GSCLSP.Server.Handlers
             var uri = request.TextDocument.Uri;
             var currentFilePath = uri.GetFileSystemPath();
 
-            var rawDumpPath = _configuration?.GetValue<string>("gsclsp:dumpPath");
+            var rawDumpPath = _indexer.DumpPath ?? _configuration?.GetValue<string>("gsclsp:dumpPath");
             string? normalizedDumpPath = GscIndexer.NormalizePath(rawDumpPath);
 
             // Use cached content instead of File.ReadAllLinesAsync

--- a/GSCLSP.Server/Program.cs
+++ b/GSCLSP.Server/Program.cs
@@ -1,6 +1,5 @@
 ﻿using GSCLSP.Core.Indexing;
 using GSCLSP.Server.Handlers;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
@@ -11,15 +10,10 @@ var documentStore = new GscDocumentStore();
 
 string basePath = AppDomain.CurrentDomain.BaseDirectory;
 string builtInPath = Path.Combine(basePath, "data", "iw4_builtins.json");
-string dumpIndexPath = Path.Combine(basePath, "data", "symbols.json");
 
 try
 {
     indexer.BuiltIns.LoadBuiltIns(builtInPath);
-    if (File.Exists(dumpIndexPath))
-    {
-        indexer.LoadGlobalIndex(dumpIndexPath);
-    }
 }
 catch (Exception ex)
 {
@@ -46,35 +40,20 @@ var server = await LanguageServer.From(options =>
         .WithHandler<GscCodeActionHandler>()
         .OnInitialize((server, request, token) =>
         {
-            string? workspacePath = request.RootPath ?? request.RootUri?.GetFileSystemPath();
+            var workspacePath = request.RootPath
+                ?? request.RootUri?.GetFileSystemPath()
+                ?? request.WorkspaceFolders?.FirstOrDefault()?.Uri?.GetFileSystemPath();
 
             if (!string.IsNullOrEmpty(workspacePath))
             {
-                var indexer = server.Services.GetService<GscIndexer>();
-                indexer?.IndexWorkspace(workspacePath);
+                var serverIndexer = server.Services.GetService<GscIndexer>();
+                serverIndexer?.IndexWorkspace(workspacePath);
             }
 
+            indexer.UpdateSettingDumpPath(null);
             return Task.CompletedTask;
         })
-        .OnStarted(async (server, ct) =>
-        {
-            var config = server.Configuration.GetSection("gsclsp");
-            var newPath = config.GetValue<string>("dumpPath");
-            indexer.UpdateDumpPath(newPath);
-        })
-        .OnDidChangeConfiguration(x =>
-        {
-            var settings = x.Settings?.SelectToken("gsclsp");
-
-            if (settings != null)
-            {
-                var newPath = settings.Value<string>("dumpPath");
-                Console.Error.WriteLine($"New Path {newPath}");
-                indexer.UpdateDumpPath(newPath);
-            }
-        })
 );
-
 
 Console.Error.WriteLine("Running!");
 


### PR DESCRIPTION
Read a gsclsp.config.json file in the current workspace instead of a global VS Setting - #12 

- Auto create file if it doesn't exist on extension load
- Add watcher for file changes
- Index all functions on dumpPath change/load
- Fix issue with auto complete not finding functions when dumpPath changes