### PR TITLE
feature: add Target Game to UI, color inactive regions, and dynamic built-in detection

### DIFF
--- a/GSCLSP.Benchmark/GscDiagnosticsHandlerBenchmark.cs
+++ b/GSCLSP.Benchmark/GscDiagnosticsHandlerBenchmark.cs
@@ -105,7 +105,7 @@ on_player_spawn(player)
         _indexer.IndexWorkspace(_tempDir);
         _testFilePath = Path.Combine(_tempDir, "scripts", "main.gsc");
 
-        _diagnosticsHandler = new GscDiagnosticsHandler(_indexer, null!);
+        _diagnosticsHandler = new GscDiagnosticsHandler(_indexer, null!, new GscDocumentStore());
     }
 
     [Benchmark]

--- a/GSCLSP.Core/Diagnostics/GscDeadCodeAnalyzer.cs
+++ b/GSCLSP.Core/Diagnostics/GscDeadCodeAnalyzer.cs
@@ -1,0 +1,229 @@
+using GSCLSP.Lexer;
+using static GSCLSP.Core.Models.RegexPatterns;
+
+namespace GSCLSP.Core.Diagnostics;
+
+public static class GscDeadCodeAnalyzer
+{
+    public readonly record struct EarlyReturn(int Line, int Column, int Length);
+
+    public sealed record Result(List<InactiveRange> DeadRanges, List<EarlyReturn> EarlyReturns);
+
+    public static Result Analyze(string[] lines, IReadOnlyList<Token> tokens)
+    {
+        var deadRanges = new List<InactiveRange>();
+        var earlyReturns = new List<EarlyReturn>();
+
+        var sig = tokens.Where(IsSignificant).ToList();
+
+        foreach (var functionBodyOpenBraceIndex in FindFunctionBodyOpenBraces(lines, sig))
+        {
+            int idx = functionBodyOpenBraceIndex;
+            ParseBlock(sig, ref idx, isFunctionBody: true, deadRanges, earlyReturns);
+        }
+
+        return new Result(deadRanges, earlyReturns);
+    }
+
+    private static void ParseBlock(
+        List<Token> sig,
+        ref int idx,
+        bool isFunctionBody,
+        List<InactiveRange> deadRanges,
+        List<EarlyReturn> earlyReturns)
+    {
+        int openBraceLine = sig[idx].Line;
+        idx++;
+
+        while (idx < sig.Count && sig[idx].Kind != TokenKind.CloseBrace)
+        {
+            var t = sig[idx];
+            bool isTopLevelReturn = isFunctionBody && IsReturnKeyword(t);
+            var returnLine = t.Line;
+            var returnCol = t.Column;
+            var returnLen = t.Length;
+
+            ParseStatement(sig, ref idx, deadRanges, earlyReturns);
+
+            if (isTopLevelReturn)
+            {
+                // check whether anything significant remains before the closing brace
+                if (idx < sig.Count && sig[idx].Kind != TokenKind.CloseBrace)
+                {
+                    var closeBraceIdx = FindMatchingCloseBraceFrom(sig, idx);
+                    if (closeBraceIdx < 0) return;
+
+                    var closeBraceLine = sig[closeBraceIdx].Line;
+                    
+                    // line after the return's semicolon through the line before the closing brace.
+                    var semicolonLine = FindPrevSemicolonLine(sig, idx - 1, stopAfter: returnLine);
+                    var deadStart = Math.Max(returnLine + 1, semicolonLine + 1);
+                    var deadEnd = closeBraceLine - 1;
+                    if (deadEnd >= deadStart)
+                        deadRanges.Add(new InactiveRange(deadStart, deadEnd));
+
+                    earlyReturns.Add(new EarlyReturn(returnLine, returnCol, returnLen));
+
+                    idx = closeBraceIdx;
+                }
+                return;
+            }
+        }
+
+        if (idx < sig.Count && sig[idx].Kind == TokenKind.CloseBrace) idx++;
+    }
+
+    private static void ParseStatement(
+        List<Token> sig,
+        ref int idx,
+        List<InactiveRange> deadRanges,
+        List<EarlyReturn> earlyReturns)
+    {
+        if (idx >= sig.Count) return;
+        var t = sig[idx];
+
+        if (t.Kind == TokenKind.OpenBrace)
+        {
+            ParseBlock(sig, ref idx, isFunctionBody: false, deadRanges, earlyReturns);
+            return;
+        }
+
+        if (t.Kind == TokenKind.Semicolon) { idx++; return; }
+
+        if (IsKeyword(t, "if") || IsKeyword(t, "while") || IsKeyword(t, "for") || IsKeyword(t, "foreach"))
+        {
+            idx++;
+            SkipParenGroup(sig, ref idx);
+            ParseStatement(sig, ref idx, deadRanges, earlyReturns);
+            if (IsKeyword(t, "if") && idx < sig.Count && IsKeyword(sig[idx], "else"))
+            {
+                idx++;
+                ParseStatement(sig, ref idx, deadRanges, earlyReturns);
+            }
+            return;
+        }
+
+        if (IsKeyword(t, "do"))
+        {
+            idx++;
+            ParseStatement(sig, ref idx, deadRanges, earlyReturns);
+            if (idx < sig.Count && IsKeyword(sig[idx], "while"))
+            {
+                idx++;
+                SkipParenGroup(sig, ref idx);
+                SkipToSemicolon(sig, ref idx);
+            }
+            return;
+        }
+
+        if (IsKeyword(t, "switch"))
+        {
+            idx++;
+            SkipParenGroup(sig, ref idx);
+            if (idx < sig.Count && sig[idx].Kind == TokenKind.OpenBrace)
+                ParseBlock(sig, ref idx, isFunctionBody: false, deadRanges, earlyReturns);
+            return;
+        }
+
+        SkipToSemicolon(sig, ref idx);
+    }
+
+    private static void SkipParenGroup(List<Token> sig, ref int idx)
+    {
+        if (idx >= sig.Count || sig[idx].Kind != TokenKind.OpenParen) return;
+        int depth = 0;
+        while (idx < sig.Count)
+        {
+            var k = sig[idx].Kind;
+            if (k == TokenKind.OpenParen) depth++;
+            else if (k == TokenKind.CloseParen)
+            {
+                depth--;
+                if (depth == 0) { idx++; return; }
+            }
+            idx++;
+        }
+    }
+
+    private static void SkipToSemicolon(List<Token> sig, ref int idx)
+    {
+        int parenDepth = 0;
+        int bracketDepth = 0;
+        while (idx < sig.Count)
+        {
+            var k = sig[idx].Kind;
+            if (k == TokenKind.OpenParen) parenDepth++;
+            else if (k == TokenKind.CloseParen) parenDepth = Math.Max(0, parenDepth - 1);
+            else if (k == TokenKind.OpenBracket) bracketDepth++;
+            else if (k == TokenKind.CloseBracket) bracketDepth = Math.Max(0, bracketDepth - 1);
+            else if (k == TokenKind.Semicolon && parenDepth == 0 && bracketDepth == 0)
+            {
+                idx++;
+                return;
+            }
+            else if (k == TokenKind.CloseBrace && parenDepth == 0 && bracketDepth == 0)
+            {
+                // missing semicolon so let the outer block handle the `}`
+                return;
+            }
+            idx++;
+        }
+    }
+
+    private static int FindMatchingCloseBraceFrom(List<Token> sig, int startIdx)
+    {
+        int depth = 1;
+        for (int i = startIdx; i < sig.Count; i++)
+        {
+            if (sig[i].Kind == TokenKind.OpenBrace) depth++;
+            else if (sig[i].Kind == TokenKind.CloseBrace)
+            {
+                depth--;
+                if (depth == 0) return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int FindPrevSemicolonLine(List<Token> sig, int startIdx, int stopAfter)
+    {
+        for (int i = startIdx; i >= 0 && sig[i].Line >= stopAfter; i--)
+        {
+            if (sig[i].Kind == TokenKind.Semicolon) return sig[i].Line;
+        }
+        return stopAfter;
+    }
+
+    private static IEnumerable<int> FindFunctionBodyOpenBraces(string[] lines, List<Token> sig)
+    {
+        for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            if (line.Length == 0 || char.IsWhiteSpace(line[0])) continue;
+            if (line.TrimEnd().EndsWith(';')) continue;
+            if (!FunctionMultiLineRegex().Match(line).Success) continue;
+
+            for (int i = 0; i < sig.Count; i++)
+            {
+                if (sig[i].Line < lineIndex) continue;
+                if (sig[i].Kind == TokenKind.OpenBrace)
+                {
+                    yield return i;
+                    break;
+                }
+            }
+        }
+    }
+
+    private static bool IsReturnKeyword(Token t) =>
+        (t.Kind is TokenKind.Identifier or TokenKind.Keyword) && t.Text.Equals("return", StringComparison.Ordinal);
+
+    private static bool IsKeyword(Token t, string text) =>
+        (t.Kind is TokenKind.Identifier or TokenKind.Keyword) && t.Text.Equals(text, StringComparison.Ordinal);
+
+    private static bool IsSignificant(Token t) =>
+        t.Kind is not TokenKind.Whitespace
+            and not TokenKind.Comment
+            and not TokenKind.EndOfFile
+            and not TokenKind.BadToken;
+}

--- a/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
+++ b/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
@@ -13,10 +13,12 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer)
     public const string RecursiveFunctionWarningCode = "gsclsp.recursiveFunction";
     public const string MissingSemicolonWarningCode = "gsclsp.missingSemicolon";
     public const string InvalidBuiltinArgCountDiagnosticCode = "gsclsp.invalidBuiltinArgCount";
+    public const string EarlyReturnWarningCode = "gsclsp.earlyReturn";
 
     private const string RecursiveWarningMuteKey = "recursive-function";
     private const string MissingSemicolonMuteKey = "missing-semicolon";
     private const string BuiltinArgCountMuteKey = "builtin-arg-count";
+    private const string EarlyReturnMuteKey = "early-return";
     private static readonly bool ResolutionTraceEnabled =
         string.Equals(Environment.GetEnvironmentVariable("GSCLSP_TRACE_RESOLUTION"), "1", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(Environment.GetEnvironmentVariable("GSCLSP_TRACE_RESOLUTION"), "true", StringComparison.OrdinalIgnoreCase);
@@ -105,6 +107,31 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer)
         }
 
         diagnostics.AddRange(CollectRecursiveFunctionWarnings(lines, tokensByLine, muteConfig, devBlockMask));
+        diagnostics.AddRange(CollectEarlyReturnWarnings(lines, lexed.Tokens, muteConfig));
+
+        return diagnostics;
+    }
+
+    private static List<Diagnostic> CollectEarlyReturnWarnings(string[] lines, IReadOnlyList<Token> tokens, MuteConfig muteConfig)
+    {
+        var diagnostics = new List<Diagnostic>();
+        var result = GscDeadCodeAnalyzer.Analyze(lines, tokens);
+
+        foreach (var er in result.EarlyReturns)
+        {
+            if (IsMuted(muteConfig, EarlyReturnMuteKey, er.Line)) continue;
+
+            diagnostics.Add(new Diagnostic
+            {
+                Severity = DiagnosticSeverity.Warning,
+                Source = "gsclsp",
+                Code = EarlyReturnWarningCode,
+                Message = "Early return leaves unreachable code below.",
+                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                    new Position(er.Line, er.Column),
+                    new Position(er.Line, er.Column + er.Length))
+            });
+        }
 
         return diagnostics;
     }

--- a/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
+++ b/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
@@ -107,18 +107,25 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer)
         }
 
         diagnostics.AddRange(CollectRecursiveFunctionWarnings(lines, tokensByLine, muteConfig, devBlockMask));
-        diagnostics.AddRange(CollectEarlyReturnWarnings(lines, lexed.Tokens, muteConfig));
+        diagnostics.AddRange(CollectEarlyReturnWarnings(lines, lexed.Tokens, muteConfig, devBlockMask));
 
         return diagnostics;
     }
 
-    private static List<Diagnostic> CollectEarlyReturnWarnings(string[] lines, IReadOnlyList<Token> tokens, MuteConfig muteConfig)
+    private static List<Diagnostic> CollectEarlyReturnWarnings(
+        string[] lines,
+        IReadOnlyList<Token> tokens,
+        MuteConfig muteConfig,
+        bool[] devBlockMask)
     {
         var diagnostics = new List<Diagnostic>();
         var result = GscDeadCodeAnalyzer.Analyze(lines, tokens);
 
         foreach (var er in result.EarlyReturns)
         {
+            if (er.Line >= 0 && er.Line < devBlockMask.Length && devBlockMask[er.Line])
+                continue;
+
             if (IsMuted(muteConfig, EarlyReturnMuteKey, er.Line)) continue;
 
             diagnostics.Add(new Diagnostic
@@ -769,6 +776,12 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer)
             if (normalized is "builtin-arg-count" or "builtin-args" or "arity")
             {
                 keys.Add(BuiltinArgCountMuteKey);
+                continue;
+            }
+
+            if (normalized is "early-return" or "early-returns" or "unreachable")
+            {
+                keys.Add(EarlyReturnMuteKey);
             }
         }
 

--- a/GSCLSP.Core/Diagnostics/GscInactiveRegionAnalyzer.cs
+++ b/GSCLSP.Core/Diagnostics/GscInactiveRegionAnalyzer.cs
@@ -1,0 +1,120 @@
+namespace GSCLSP.Core.Diagnostics;
+
+public readonly record struct InactiveRange(int StartLine, int EndLine);
+
+public static class GscInactiveRegionAnalyzer
+{
+    public static List<InactiveRange> Analyze(string[] lines, string currentGame)
+    {
+        var result = new List<InactiveRange>();
+        var stack = new Stack<Frame>();
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var trimmed = lines[i].TrimStart();
+            if (trimmed.Length == 0 || trimmed[0] != '#') continue;
+
+            if (TryMatchDirective(trimmed, "#ifdef", out var name))
+            {
+                PushBranch(stack, matches: NameMatches(name, currentGame), lineIndex: i);
+                continue;
+            }
+
+            if (TryMatchDirective(trimmed, "#ifndef", out name))
+            {
+                PushBranch(stack, matches: !NameMatches(name, currentGame), lineIndex: i);
+                continue;
+            }
+
+            if (TryMatchDirective(trimmed, "#elifdef", out name))
+            {
+                SwitchBranch(stack, result, matches: NameMatches(name, currentGame), lineIndex: i);
+                continue;
+            }
+
+            if (TryMatchDirective(trimmed, "#elifndef", out name))
+            {
+                SwitchBranch(stack, result, matches: !NameMatches(name, currentGame), lineIndex: i);
+                continue;
+            }
+
+            if (IsBareDirective(trimmed, "#else"))
+            {
+                SwitchBranch(stack, result, matches: true, lineIndex: i);
+                continue;
+            }
+
+            if (IsBareDirective(trimmed, "#endif"))
+            {
+                if (stack.Count == 0) continue;
+                var top = stack.Pop();
+                FlushIfInactive(result, top, endLine: i - 1);
+            }
+        }
+
+        return result;
+    }
+
+    private static void PushBranch(Stack<Frame> stack, bool matches, int lineIndex)
+    {
+        var parentInactive = stack.Count > 0 && stack.Peek().IsEffectivelyInactive();
+        var branchActive = !parentInactive && matches;
+        stack.Push(new Frame(parentInactive, BranchActive: branchActive, AnyBranchTaken: branchActive, BranchStartLine: lineIndex));
+    }
+
+    private static void SwitchBranch(Stack<Frame> stack, List<InactiveRange> result, bool matches, int lineIndex)
+    {
+        if (stack.Count == 0) return;
+
+        var top = stack.Pop();
+        FlushIfInactive(result, top, endLine: lineIndex - 1);
+
+        var branchActive = !top.ParentInactive && !top.AnyBranchTaken && matches;
+        stack.Push(top with
+        {
+            BranchActive = branchActive,
+            AnyBranchTaken = top.AnyBranchTaken || branchActive,
+            BranchStartLine = lineIndex,
+        });
+    }
+
+    private static void FlushIfInactive(List<InactiveRange> result, Frame frame, int endLine)
+    {
+        if (frame.ParentInactive || frame.BranchActive) return;
+        if (endLine < frame.BranchStartLine + 1) return;
+        result.Add(new InactiveRange(frame.BranchStartLine + 1, endLine));
+    }
+
+    private static bool NameMatches(string directiveName, string currentGame) =>
+        directiveName.Equals(currentGame, StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryMatchDirective(string trimmedLine, string directive, out string argument)
+    {
+        argument = string.Empty;
+        if (!trimmedLine.StartsWith(directive, StringComparison.Ordinal)) return false;
+        if (trimmedLine.Length == directive.Length) return false;
+        if (!char.IsWhiteSpace(trimmedLine[directive.Length])) return false;
+
+        var rest = trimmedLine[directive.Length..].Trim();
+        int end = 0;
+        while (end < rest.Length && (char.IsLetterOrDigit(rest[end]) || rest[end] == '_'))
+            end++;
+
+        if (end == 0) return false;
+        argument = rest[..end];
+        return true;
+    }
+
+    private static bool IsBareDirective(string trimmedLine, string directive)
+    {
+        if (!trimmedLine.StartsWith(directive, StringComparison.Ordinal)) return false;
+        if (trimmedLine.Length == directive.Length) return true;
+        var next = trimmedLine[directive.Length];
+        return char.IsWhiteSpace(next) || next == '/';
+    }
+
+    private sealed record Frame(bool ParentInactive, bool BranchActive, bool AnyBranchTaken, int BranchStartLine)
+    {
+        public bool IsEffectivelyInactive() => ParentInactive || !BranchActive;
+    }
+}

--- a/GSCLSP.Core/Indexing/BuiltInProvider.cs
+++ b/GSCLSP.Core/Indexing/BuiltInProvider.cs
@@ -49,6 +49,11 @@ public class BuiltInProvider
                     LoadEntries(methods, builtInMethods, SymbolType.Method);
                 }
             }
+            else
+            {
+                Console.Error.WriteLine($"[Warning] Unexpected built-ins JSON root kind '{root.ValueKind}' in: {jsonPath}");
+                return;
+            }
 
             ReplaceSnapshot(builtInFunctions, builtInMethods);
             Console.Error.WriteLine($"Loaded {builtInFunctions.Count} engine built-in functions and {builtInMethods.Count} engine built-in methods.");

--- a/GSCLSP.Core/Indexing/BuiltInProvider.cs
+++ b/GSCLSP.Core/Indexing/BuiltInProvider.cs
@@ -169,4 +169,22 @@ public class BuiltInProvider
             ? _builtInMethods.Values.Concat(_builtInFunctions.Values)
             : _builtInFunctions.Values.Concat(_builtInMethods.Values);
     }
+
+    public void LoadNameOnlyBuiltIns(IEnumerable<string> functionNames, IEnumerable<string> methodNames)
+    {
+        _builtInFunctions.Clear();
+        _builtInMethods.Clear();
+
+        foreach (var name in functionNames)
+        {
+            if (string.IsNullOrWhiteSpace(name)) continue;
+            _builtInFunctions[name] = new GscSymbol(name, "Engine", 0, string.Empty, SymbolType.Function);
+        }
+
+        foreach (var name in methodNames)
+        {
+            if (string.IsNullOrWhiteSpace(name)) continue;
+            _builtInMethods[name] = new GscSymbol(name, "Engine", 0, string.Empty, SymbolType.Method);
+        }
+    }
 }

--- a/GSCLSP.Core/Indexing/BuiltInProvider.cs
+++ b/GSCLSP.Core/Indexing/BuiltInProvider.cs
@@ -11,8 +11,9 @@ public class BuiltInProvider
         "iprintlnbold"
     };
 
-    private readonly Dictionary<string, GscSymbol> _builtInFunctions = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, GscSymbol> _builtInMethods = new(StringComparer.OrdinalIgnoreCase);
+    private BuiltInSnapshot _snapshot = new(
+        new Dictionary<string, GscSymbol>(StringComparer.OrdinalIgnoreCase),
+        new Dictionary<string, GscSymbol>(StringComparer.OrdinalIgnoreCase));
 
     public void LoadBuiltIns(string jsonPath)
     {
@@ -24,33 +25,33 @@ public class BuiltInProvider
 
         try
         {
-            _builtInFunctions.Clear();
-            _builtInMethods.Clear();
-
             var json = File.ReadAllText(jsonPath);
             using var document = JsonDocument.Parse(json);
             var root = document.RootElement;
+            var builtInFunctions = new Dictionary<string, GscSymbol>(StringComparer.OrdinalIgnoreCase);
+            var builtInMethods = new Dictionary<string, GscSymbol>(StringComparer.OrdinalIgnoreCase);
 
             if (root.ValueKind == JsonValueKind.Array)
             {
                 // Legacy format: [ { name, args: [ { name } ] } ]
-                LoadEntries(root, _builtInFunctions, SymbolType.Function);
+                LoadEntries(root, builtInFunctions, SymbolType.Function);
             }
             else if (root.ValueKind == JsonValueKind.Object)
             {
                 // New format: { functions: [...], methods: [...] }
                 if (root.TryGetProperty("functions", out var functions) && functions.ValueKind == JsonValueKind.Array)
                 {
-                    LoadEntries(functions, _builtInFunctions, SymbolType.Function);
+                    LoadEntries(functions, builtInFunctions, SymbolType.Function);
                 }
 
                 if (root.TryGetProperty("methods", out var methods) && methods.ValueKind == JsonValueKind.Array)
                 {
-                    LoadEntries(methods, _builtInMethods, SymbolType.Method);
+                    LoadEntries(methods, builtInMethods, SymbolType.Method);
                 }
             }
 
-            Console.Error.WriteLine($"Loaded {_builtInFunctions.Count} engine built-in functions and {_builtInMethods.Count} engine built-in methods.");
+            ReplaceSnapshot(builtInFunctions, builtInMethods);
+            Console.Error.WriteLine($"Loaded {builtInFunctions.Count} engine built-in functions and {builtInMethods.Count} engine built-in methods.");
         }
         catch (Exception ex)
         {
@@ -146,45 +147,59 @@ public class BuiltInProvider
 
     public GscSymbol? GetBuiltIn(string name, bool preferMethod = false)
     {
+        var snapshot = _snapshot;
+
         if (preferMethod)
         {
-            if (_builtInMethods.TryGetValue(name, out var methodSymbol))
+            if (snapshot.Methods.TryGetValue(name, out var methodSymbol))
                 return methodSymbol;
 
-            return _builtInFunctions.TryGetValue(name, out var fallbackFunction) ? fallbackFunction : null;
+            return snapshot.Functions.TryGetValue(name, out var fallbackFunction) ? fallbackFunction : null;
         }
 
-        if (_builtInFunctions.TryGetValue(name, out var functionSymbol))
+        if (snapshot.Functions.TryGetValue(name, out var functionSymbol))
             return functionSymbol;
 
-        return _builtInMethods.TryGetValue(name, out var fallbackMethod) ? fallbackMethod : null;
+        return snapshot.Methods.TryGetValue(name, out var fallbackMethod) ? fallbackMethod : null;
     }
 
     public IEnumerable<string> GetNames() =>
-        _builtInFunctions.Keys.Concat(_builtInMethods.Keys).Distinct(StringComparer.OrdinalIgnoreCase);
+        _snapshot.Functions.Keys.Concat(_snapshot.Methods.Keys).Distinct(StringComparer.OrdinalIgnoreCase);
 
     public IEnumerable<GscSymbol> GetAll(bool preferMethodsFirst = false)
     {
+        var snapshot = _snapshot;
         return preferMethodsFirst
-            ? _builtInMethods.Values.Concat(_builtInFunctions.Values)
-            : _builtInFunctions.Values.Concat(_builtInMethods.Values);
+            ? snapshot.Methods.Values.Concat(snapshot.Functions.Values)
+            : snapshot.Functions.Values.Concat(snapshot.Methods.Values);
     }
 
     public void LoadNameOnlyBuiltIns(IEnumerable<string> functionNames, IEnumerable<string> methodNames)
     {
-        _builtInFunctions.Clear();
-        _builtInMethods.Clear();
+        var builtInFunctions = new Dictionary<string, GscSymbol>(StringComparer.OrdinalIgnoreCase);
+        var builtInMethods = new Dictionary<string, GscSymbol>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var name in functionNames)
         {
             if (string.IsNullOrWhiteSpace(name)) continue;
-            _builtInFunctions[name] = new GscSymbol(name, "Engine", 0, string.Empty, SymbolType.Function);
+            builtInFunctions[name] = new GscSymbol(name, "Engine", 0, string.Empty, SymbolType.Function);
         }
 
         foreach (var name in methodNames)
         {
             if (string.IsNullOrWhiteSpace(name)) continue;
-            _builtInMethods[name] = new GscSymbol(name, "Engine", 0, string.Empty, SymbolType.Method);
+            builtInMethods[name] = new GscSymbol(name, "Engine", 0, string.Empty, SymbolType.Method);
         }
+
+        ReplaceSnapshot(builtInFunctions, builtInMethods);
     }
+
+    private void ReplaceSnapshot(Dictionary<string, GscSymbol> functions, Dictionary<string, GscSymbol> methods)
+    {
+        Interlocked.Exchange(ref _snapshot, new BuiltInSnapshot(functions, methods));
+    }
+
+    private sealed record BuiltInSnapshot(
+        Dictionary<string, GscSymbol> Functions,
+        Dictionary<string, GscSymbol> Methods);
 }

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -1,6 +1,7 @@
 ﻿using GSCLSP.Core.Models;
 using GSCLSP.Core.Parsing;
 using GSCLSP.Core.Services;
+using GSCLSP.Core.Tools;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -15,6 +16,8 @@ public partial class GscIndexer
     public int SymbolCount => _symbols.Count;
     public BuiltInProvider BuiltIns { get; } = new();
     public string? DumpPath { get; private set; }
+    public string CurrentGame { get; private set; } = "iw4";
+    public event Action<string>? GameChanged;
     public List<GscSymbol> WorkspaceSymbols { get; private set; } = [];
     private readonly Dictionary<string, GscFileMap> _workspaceFileMaps = [];
     private readonly Dictionary<string, GscFileMap> _fileMaps = [];
@@ -921,12 +924,17 @@ public partial class GscIndexer
         return clean;
     }
 
+    private static readonly TimeSpan GscToolCacheMaxAge = TimeSpan.FromDays(7);
+
     private void LoadConfiguredBuiltIns(bool hasWorkspaceConfig, string? workspaceGame)
     {
         var game = ResolveGameValue(hasWorkspaceConfig, workspaceGame);
         var normalizedGame = string.IsNullOrWhiteSpace(game)
             ? "iw4"
             : game.Trim().ToLowerInvariant();
+
+        var gameChanged = !string.Equals(CurrentGame, normalizedGame, StringComparison.Ordinal);
+        CurrentGame = normalizedGame;
 
         var basePath = AppDomain.CurrentDomain.BaseDirectory;
         var dataPath = Path.Combine(basePath, "data");
@@ -937,22 +945,63 @@ public partial class GscIndexer
         if (File.Exists(requestedPath))
         {
             BuiltIns.LoadBuiltIns(requestedPath);
-            Console.Error.WriteLine($"GSCLSP: loaded built-ins for game '{normalizedGame}'.");
+            Console.Error.WriteLine($"GSCLSP: loaded builtins for game '{normalizedGame}'.");
+            if (gameChanged) GameChanged?.Invoke(normalizedGame);
+            return;
+        }
+
+        if (GscToolBuiltInsLoader.IsSupported(normalizedGame))
+        {
+            var cached = GscToolBuiltInsLoader.TryLoadFromCache(normalizedGame);
+            if (cached != null)
+            {
+                BuiltIns.LoadNameOnlyBuiltIns(cached.Functions, cached.Methods);
+                Console.Error.WriteLine($"GSCLSP: Loaded cached builtins for game '{normalizedGame}'.");
+                if (gameChanged) GameChanged?.Invoke(normalizedGame);
+
+                if (GscToolBuiltInsLoader.IsCacheStale(normalizedGame, GscToolCacheMaxAge))
+                    _ = RefreshGscToolBuiltInsAsync(normalizedGame);
+            }
+            else
+            {
+                // Clear stale (previous game's) built-ins so they don't bleed into diagnostics until the fetch completes.
+                BuiltIns.LoadNameOnlyBuiltIns([], []);
+                Console.Error.WriteLine($"GSCLSP: no cache for '{normalizedGame}'; fetching from gsc-tool.");
+                _ = RefreshGscToolBuiltInsAsync(normalizedGame);
+            }
             return;
         }
 
         if (!normalizedGame.Equals("iw4", StringComparison.OrdinalIgnoreCase))
         {
-            Console.Error.WriteLine($"GSCLSP: built-ins for game '{normalizedGame}' not found. Falling back to iw4_builtins.json.");
+            Console.Error.WriteLine($"GSCLSP: Builtins for game '{normalizedGame}' not found, using iw4_builtins.json instead...");
         }
 
         if (File.Exists(fallbackPath))
         {
             BuiltIns.LoadBuiltIns(fallbackPath);
+            if (gameChanged) GameChanged?.Invoke(normalizedGame);
             return;
         }
 
-        Console.Error.WriteLine("GSCLSP: no built-ins file found (expected data/iw4_builtins.json).");
+        Console.Error.WriteLine("GSCLSP: No builtins file found, expected data/iw4_builtins.json");
+    }
+
+    private async Task RefreshGscToolBuiltInsAsync(string game)
+    {
+        var fetched = await GscToolBuiltInsLoader.FetchAsync(game).ConfigureAwait(false);
+        if (fetched == null)
+        {
+            await Console.Error.WriteLineAsync($"GSCLSP: gsc-tool fetch for '{game}' failed or unsupported.");
+            return;
+        }
+
+        if (!string.Equals(CurrentGame, game, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        BuiltIns.LoadNameOnlyBuiltIns(fetched.Functions, fetched.Methods);
+        await Console.Error.WriteLineAsync($"GSCLSP: Refreshed gsc-tool built-ins for game '{game}'.");
+        GameChanged?.Invoke(game);
     }
 
     private static string ResolveGameValue(bool hasWorkspaceConfig, string? workspaceGame)

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -966,7 +966,8 @@ public partial class GscIndexer
             {
                 // Clear stale (previous game's) built-ins so they don't bleed into diagnostics until the fetch completes.
                 BuiltIns.LoadNameOnlyBuiltIns([], []);
-                Console.Error.WriteLine($"GSCLSP: no cache for '{normalizedGame}'; fetching from gsc-tool.");
+                Console.Error.WriteLine($"GSCLSP: No cache for '{normalizedGame}', fetching from gsc-tool...");
+                if (gameChanged) GameChanged?.Invoke(normalizedGame);
                 _ = RefreshGscToolBuiltInsAsync(normalizedGame);
             }
             return;
@@ -985,6 +986,7 @@ public partial class GscIndexer
         }
 
         Console.Error.WriteLine("GSCLSP: No builtins file found, expected data/iw4_builtins.json");
+        if (gameChanged) GameChanged?.Invoke(normalizedGame);
     }
 
     private async Task RefreshGscToolBuiltInsAsync(string game)
@@ -999,9 +1001,27 @@ public partial class GscIndexer
         if (!string.Equals(CurrentGame, game, StringComparison.OrdinalIgnoreCase))
             return;
 
+        var previousFunctions = BuiltIns.GetAll()
+            .Where(symbol => symbol.Type == SymbolType.Function)
+            .Select(symbol => symbol.Name)
+            .ToArray();
+        var previousMethods = BuiltIns.GetAll(preferMethodsFirst: true)
+            .Where(symbol => symbol.Type == SymbolType.Method)
+            .Select(symbol => symbol.Name)
+            .ToArray();
+        var builtInsChanged = !BuiltInNamesEqual(previousFunctions, fetched.Functions)
+            || !BuiltInNamesEqual(previousMethods, fetched.Methods);
+
         BuiltIns.LoadNameOnlyBuiltIns(fetched.Functions, fetched.Methods);
         await Console.Error.WriteLineAsync($"GSCLSP: Refreshed gsc-tool built-ins for game '{game}'.");
-        GameChanged?.Invoke(game);
+        if (builtInsChanged)
+            GameChanged?.Invoke(game);
+    }
+
+    private static bool BuiltInNamesEqual(IEnumerable<string> left, IEnumerable<string> right)
+    {
+        return new HashSet<string>(left, StringComparer.OrdinalIgnoreCase)
+            .SetEquals(right);
     }
 
     private static string ResolveGameValue(bool hasWorkspaceConfig, string? workspaceGame)

--- a/GSCLSP.Core/Models/GscLanguageKeywords.cs
+++ b/GSCLSP.Core/Models/GscLanguageKeywords.cs
@@ -4,16 +4,26 @@ public static class GscLanguageKeywords
 {
     public static readonly HashSet<string> DiagnosticReservedWords = new(StringComparer.OrdinalIgnoreCase)
     {
-        "if", "else", "for", "foreach", "while", "switch", "return", "wait",
-        "waittill", "waittillmatch", "waittillframeend", "notify", "endon",
-        "thread", "childthread", "break", "continue", "case", "default"
+        "if", "else", "do", "while", "for", "foreach", "in",
+        "switch", "case", "default", "break", "continue", "return",
+        "wait", "waitframe", "waittill", "waittillmatch", "waittillframeend",
+        "notify", "endon",
+        "thread", "childthread", "thisthread", "call",
+        "breakpoint", "prof_begin", "prof_end",
+        "assert", "assertex", "assertmsg",
+        "true", "false", "undefined",
+        "size", "game", "self", "anim", "level",
+        "isdefined", "istrue"
     };
 
     public static readonly HashSet<string> LocalVariableReservedWords = new(StringComparer.OrdinalIgnoreCase)
     {
-        "if", "else", "for", "foreach", "while", "switch", "return", "wait",
-        "waittill", "waittillmatch", "waittillframeend", "notify", "endon",
-        "thread", "childthread", "break", "continue", "case", "default",
-        "true", "false", "undefined", "self", "level", "game"
+        "if", "else", "do", "while", "for", "foreach", "in",
+        "switch", "case", "default", "break", "continue", "return",
+        "wait", "waitframe", "waittill", "waittillmatch", "waittillframeend",
+        "notify", "endon",
+        "thread", "childthread", "thisthread", "call",
+        "true", "false", "undefined",
+        "self", "level", "game", "anim"
     };
 }

--- a/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
+++ b/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
@@ -12,7 +12,6 @@ public static class GscToolBuiltInsLoader
     {
         "iw5", "iw6", "iw7", "iw8", "iw9",
         "s1", "s2", "s4",
-        "t6", "t7", "t8", "t9",
         "h1", "h2",
     };
 
@@ -82,6 +81,10 @@ public static class GscToolBuiltInsLoader
 
             SaveCache(key, functions, methods);
             return new NameLists(functions, methods);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {

--- a/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
+++ b/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
@@ -6,13 +6,16 @@ namespace GSCLSP.Core.Tools;
 
 public static class GscToolBuiltInsLoader
 {
-    private const string RawBaseUrl = "https://raw.githubusercontent.com/xensik/gsc-tool/refs/heads/dev/src/gsc/engine";
-
     public static readonly HashSet<string> SupportedGames = new(StringComparer.OrdinalIgnoreCase)
     {
         "iw5", "iw6", "iw7", "iw8", "iw9",
         "s1", "s2", "s4",
         "h1", "h2",
+    };
+
+    private static readonly HttpClient http = new()
+    {
+        BaseAddress = new Uri("https://raw.githubusercontent.com/xensik/gsc-tool/refs/heads/dev/src/gsc/engine"),
     };
 
     public static bool IsSupported(string game) => SupportedGames.Contains(game);
@@ -61,13 +64,12 @@ public static class GscToolBuiltInsLoader
 
         try
         {
-            using var http = new HttpClient();
-            var funcTask = TryGetFirstAvailableAsync(http, ct,
-                $"{RawBaseUrl}/{key}_func.cpp",
-                $"{RawBaseUrl}/{key}_pc_func.cpp");
-            var methTask = TryGetFirstAvailableAsync(http, ct,
-                $"{RawBaseUrl}/{key}_meth.cpp",
-                $"{RawBaseUrl}/{key}_pc_meth.cpp");
+            var funcTask = TryGetFirstAvailableAsync(ct,
+                $"{key}_func.cpp",
+                $"{key}_pc_func.cpp");
+            var methTask = TryGetFirstAvailableAsync(ct,
+                $"{key}_meth.cpp",
+                $"{key}_pc_meth.cpp");
 
             await Task.WhenAll(funcTask, methTask);
 
@@ -92,7 +94,7 @@ public static class GscToolBuiltInsLoader
         }
     }
 
-    private static async Task<string?> TryGetFirstAvailableAsync(HttpClient http, CancellationToken ct, params string[] urls)
+    private static async Task<string?> TryGetFirstAvailableAsync(CancellationToken ct, params string[] urls)
     {
         foreach (var url in urls)
         {

--- a/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
+++ b/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
@@ -93,7 +93,9 @@ public static class GscToolBuiltInsLoader
     {
         foreach (var url in urls)
         {
+            ct.ThrowIfCancellationRequested();
             try { return await http.GetStringAsync(url, ct); }
+            catch (OperationCanceledException) { throw; }
             catch { }
         }
         return null;

--- a/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
+++ b/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
@@ -15,7 +15,7 @@ public static class GscToolBuiltInsLoader
 
     private static readonly HttpClient http = new()
     {
-        BaseAddress = new Uri("https://raw.githubusercontent.com/xensik/gsc-tool/refs/heads/dev/src/gsc/engine"),
+        BaseAddress = new Uri("https://raw.githubusercontent.com/xensik/gsc-tool/refs/heads/dev/src/gsc/engine/"),
     };
 
     public static bool IsSupported(string game) => SupportedGames.Contains(game);

--- a/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
+++ b/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using static GSCLSP.Core.Models.RegexPatterns;
+
+namespace GSCLSP.Core.Tools;
+
+public static class GscToolBuiltInsLoader
+{
+    private const string RawBaseUrl = "https://raw.githubusercontent.com/xensik/gsc-tool/refs/heads/dev/src/gsc/engine";
+
+    public static readonly HashSet<string> SupportedGames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "iw5", "iw6", "iw7", "iw8", "iw9",
+        "s1", "s2", "s4",
+        "t6", "t7", "t8", "t9",
+        "h1", "h2",
+    };
+
+    public static bool IsSupported(string game) => SupportedGames.Contains(game);
+
+    public sealed record NameLists(IReadOnlyList<string> Functions, IReadOnlyList<string> Methods);
+
+    public static string CachePath(string game)
+    {
+        var root = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "gsclsp",
+            "builtins");
+        return Path.Combine(root, $"{game.ToLowerInvariant()}_gsctool.json");
+    }
+
+    public static bool IsCacheStale(string game, TimeSpan maxAge)
+    {
+        var path = CachePath(game);
+        if (!File.Exists(path)) return true;
+        return DateTime.UtcNow - File.GetLastWriteTimeUtc(path) > maxAge;
+    }
+
+    public static NameLists? TryLoadFromCache(string game)
+    {
+        try
+        {
+            var path = CachePath(game);
+            if (!File.Exists(path)) return null;
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+            var functions = ReadArray(doc.RootElement, "functions");
+            var methods = ReadArray(doc.RootElement, "methods");
+            if (functions.Count == 0 && methods.Count == 0) return null;
+            return new NameLists(functions, methods);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static async Task<NameLists?> FetchAsync(string game, CancellationToken ct = default)
+    {
+        var key = game.Trim().ToLowerInvariant();
+        if (!IsSupported(key)) return null;
+
+        try
+        {
+            using var http = new HttpClient();
+            var funcTask = TryGetFirstAvailableAsync(http, ct,
+                $"{RawBaseUrl}/{key}_func.cpp",
+                $"{RawBaseUrl}/{key}_pc_func.cpp");
+            var methTask = TryGetFirstAvailableAsync(http, ct,
+                $"{RawBaseUrl}/{key}_meth.cpp",
+                $"{RawBaseUrl}/{key}_pc_meth.cpp");
+
+            await Task.WhenAll(funcTask, methTask);
+
+            var funcSource = await funcTask;
+            var methSource = await methTask;
+            if (funcSource == null && methSource == null) return null;
+
+            var functions = ParseNames(funcSource);
+            var methods = ParseNames(methSource);
+            if (functions.Count == 0 && methods.Count == 0) return null;
+
+            SaveCache(key, functions, methods);
+            return new NameLists(functions, methods);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> TryGetFirstAvailableAsync(HttpClient http, CancellationToken ct, params string[] urls)
+    {
+        foreach (var url in urls)
+        {
+            try { return await http.GetStringAsync(url, ct); }
+            catch { }
+        }
+        return null;
+    }
+
+    private static List<string> ParseNames(string? source)
+    {
+        var result = new List<string>();
+        if (string.IsNullOrEmpty(source)) return result;
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match m in GscToolRegex().Matches(source))
+        {
+            var name = m.Groups["name"].Value;
+            if (!string.IsNullOrWhiteSpace(name) && seen.Add(name))
+                result.Add(name);
+        }
+        return result;
+    }
+
+    private static List<string> ReadArray(JsonElement root, string propertyName)
+    {
+        var result = new List<string>();
+        if (!root.TryGetProperty(propertyName, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return result;
+
+        foreach (var entry in arr.EnumerateArray())
+        {
+            if (entry.ValueKind == JsonValueKind.String)
+            {
+                var value = entry.GetString();
+                if (!string.IsNullOrWhiteSpace(value)) result.Add(value);
+            }
+        }
+        return result;
+    }
+
+    private static void SaveCache(string game, IEnumerable<string> functions, IEnumerable<string> methods)
+    {
+        try
+        {
+            var path = CachePath(game);
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+            var payload = new { functions = functions.ToArray(), methods = methods.ToArray() };
+            File.WriteAllText(path, JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch { }
+    }
+}

--- a/GSCLSP.Extension/package.json
+++ b/GSCLSP.Extension/package.json
@@ -27,6 +27,10 @@
       {
         "command": "gsclsp.browseDumpPath",
         "title": "GSC: Set Dump Folder Path"
+      },
+      {
+        "command": "gsclsp.selectTargetGame",
+        "title": "GSC: Select Target Game"
       }
     ],
     "languages": [

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -87,8 +87,8 @@ async function readTargetGame(): Promise<string | undefined> {
 async function updateStatusBar(): Promise<void> {
   if (!targetGameStatusBar) return;
   const game = (await readTargetGame()) ?? "iw4";
-  targetGameStatusBar.text = `$(chip) GSC: ${game.toUpperCase()}`;
-  targetGameStatusBar.tooltip = "Click to change the GSC target game";
+  targetGameStatusBar.text = `$(chip) GSC Target Game: ${game.toUpperCase()}`;
+  targetGameStatusBar.tooltip = "Click to change the target game for GSC";
   targetGameStatusBar.show();
 }
 

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -10,6 +10,12 @@ import {
   ProgressLocation,
   ExtensionMode,
   type WorkspaceFolder,
+  StatusBarAlignment,
+  type StatusBarItem,
+  type TextEditor,
+  type TextEditorDecorationType,
+  Range,
+  Uri,
 } from "vscode";
 import {
   LanguageClient,
@@ -19,6 +25,140 @@ import {
 } from "vscode-languageclient/node";
 
 let client: LanguageClient;
+let targetGameStatusBar: StatusBarItem | undefined;
+let inactiveDecoration: TextEditorDecorationType | undefined;
+const inactiveRangesByUri = new Map<string, Range[]>();
+
+const KNOWN_GAMES = [
+  "iw3",
+  "iw4",
+  "iw5",
+  "iw6",
+  "iw7",
+  "iw8",
+  "iw9",
+  "s1",
+  "s2",
+  "s4",
+  "t5",
+  "t6",
+  "t7",
+  "t8",
+];
+
+function targetWorkspaceFolder(): WorkspaceFolder | undefined {
+  const activeUri = window.activeTextEditor?.document.uri;
+  return activeUri
+    ? workspace.getWorkspaceFolder(activeUri) ?? workspace.workspaceFolders?.[0]
+    : workspace.workspaceFolders?.[0];
+}
+
+async function readWorkspaceConfig(
+  folder: WorkspaceFolder,
+): Promise<Record<string, unknown>> {
+  const configPath = path.join(folder.uri.fsPath, "gsclsp.config.json");
+  try {
+    const existing = await fs.readFile(configPath, "utf8");
+    const parsed = JSON.parse(existing) as unknown;
+    return parsed && typeof parsed === "object"
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeWorkspaceConfig(
+  folder: WorkspaceFolder,
+  config: Record<string, unknown>,
+): Promise<void> {
+  const configPath = path.join(folder.uri.fsPath, "gsclsp.config.json");
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf8");
+}
+
+async function readTargetGame(): Promise<string | undefined> {
+  const folder = targetWorkspaceFolder();
+  if (!folder || folder.uri.scheme !== "file") return undefined;
+  const config = await readWorkspaceConfig(folder);
+  const game = config.game;
+  return typeof game === "string" && game.length > 0 ? game : undefined;
+}
+
+async function updateStatusBar(): Promise<void> {
+  if (!targetGameStatusBar) return;
+  const game = (await readTargetGame()) ?? "iw4";
+  targetGameStatusBar.text = `$(chip) GSC: ${game.toUpperCase()}`;
+  targetGameStatusBar.tooltip = "Click to change the GSC target game";
+  targetGameStatusBar.show();
+}
+
+async function selectTargetGameCommand(): Promise<void> {
+  const folder = targetWorkspaceFolder();
+  if (!folder || folder.uri.scheme !== "file") {
+    window.showErrorMessage(
+      "GSCLSP: Open a local workspace folder to configure target game.",
+    );
+    return;
+  }
+
+  const current = (await readTargetGame()) ?? "iw4";
+  const items = KNOWN_GAMES.map((game) => ({
+    label: game.toUpperCase(),
+    description: game === current ? "(current)" : undefined,
+    game,
+  }));
+  items.push({ label: "Custom...", description: "Enter a custom value", game: "__custom__" });
+
+  const pick = await window.showQuickPick(items, {
+    placeHolder: `Select target game (current: ${current.toUpperCase()})`,
+  });
+  if (!pick) return;
+
+  let chosen = pick.game;
+  if (chosen === "__custom__") {
+    const input = await window.showInputBox({
+      prompt: "Enter target game identifier (e.g. iw9, t8)",
+      value: current,
+    });
+    if (!input) return;
+    chosen = input.trim().toLowerCase();
+    if (!chosen) return;
+  }
+
+  const config = await readWorkspaceConfig(folder);
+  config.game = chosen;
+  await writeWorkspaceConfig(folder, config);
+  await updateStatusBar();
+  window.showInformationMessage(`GSCLSP: Target game set to \"${chosen.toUpperCase()}\"`);
+}
+
+interface InactiveRegionsParams {
+  uri: string;
+  ranges: { start: number; end: number }[];
+}
+
+function applyDecorationsFor(editor: TextEditor | undefined): void {
+  if (!editor || !inactiveDecoration) return;
+  const key = editor.document.uri.toString();
+  const ranges = inactiveRangesByUri.get(key) ?? [];
+  editor.setDecorations(inactiveDecoration, ranges);
+}
+
+function handleInactiveRegions(params: InactiveRegionsParams): void {
+  const uri = Uri.parse(params.uri);
+  const key = uri.toString();
+
+  const ranges = params.ranges.map(
+    (r) => new Range(r.start, 0, r.end, Number.MAX_SAFE_INTEGER),
+  );
+  inactiveRangesByUri.set(key, ranges);
+
+  for (const editor of window.visibleTextEditors) {
+    if (editor.document.uri.toString() === key) {
+      applyDecorationsFor(editor);
+    }
+  }
+}
 
 async function ensureWorkspaceConfigFile(folder: WorkspaceFolder): Promise<void> {
   if (folder.uri.scheme !== "file") {
@@ -186,6 +326,37 @@ export async function activate(context: ExtensionContext): Promise<void> {
   } else {
     await client.setTrace(Trace.Off);
   }
+
+  targetGameStatusBar = window.createStatusBarItem(StatusBarAlignment.Right, 100);
+  targetGameStatusBar.command = "gsclsp.selectTargetGame";
+  context.subscriptions.push(targetGameStatusBar);
+  await updateStatusBar();
+
+  context.subscriptions.push(
+    commands.registerCommand("gsclsp.selectTargetGame", selectTargetGameCommand),
+  );
+
+  const configWatcher = workspace.createFileSystemWatcher("**/gsclsp.config.json");
+  configWatcher.onDidChange(() => updateStatusBar());
+  configWatcher.onDidCreate(() => updateStatusBar());
+  context.subscriptions.push(configWatcher);
+
+  inactiveDecoration = window.createTextEditorDecorationType({
+    opacity: "0.45",
+    isWholeLine: true,
+  });
+  context.subscriptions.push(inactiveDecoration);
+
+  context.subscriptions.push(
+    client.onNotification("custom/inactiveRegions", handleInactiveRegions),
+  );
+
+  context.subscriptions.push(
+    window.onDidChangeActiveTextEditor((editor) => applyDecorationsFor(editor)),
+    window.onDidChangeVisibleTextEditors((editors) => {
+      for (const e of editors) applyDecorationsFor(e);
+    }),
+  );
 }
 
 export async function deactivate(): Promise<void> {

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -29,6 +29,7 @@ let targetGameStatusBar: StatusBarItem | undefined;
 let inactiveDecoration: TextEditorDecorationType | undefined;
 const inactiveRangesByUri = new Map<string, Range[]>();
 
+// games that GSCLSP can work on no problem, but they may use IW4 builtins for now
 const KNOWN_GAMES = [
   "iw3",
   "iw4",
@@ -40,6 +41,7 @@ const KNOWN_GAMES = [
   "s1",
   "s2",
   "s4",
+  "t4",
   "t5",
   "t6",
   "t7",

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -97,9 +97,7 @@ async function updateStatusBar(): Promise<void> {
 async function selectTargetGameCommand(): Promise<void> {
   const folder = targetWorkspaceFolder();
   if (!folder || folder.uri.scheme !== "file") {
-    window.showErrorMessage(
-      "GSCLSP: Open a local workspace folder to configure target game.",
-    );
+    window.showErrorMessage("GSCLSP: Open a local workspace folder to configure target game.");
     return;
   }
 
@@ -124,7 +122,11 @@ async function selectTargetGameCommand(): Promise<void> {
     });
     if (!input) return;
     chosen = input.trim().toLowerCase();
-    if (!chosen) return;
+    if (!/^[a-z0-9_]+$/.test(chosen))
+    {
+      window.showErrorMessage(`GSCLSP: Invalid game identifier "${input}. Please try again.`);
+      return;
+    }
   }
 
   const config = await readWorkspaceConfig(folder);
@@ -150,9 +152,8 @@ function handleInactiveRegions(params: InactiveRegionsParams): void {
   const uri = Uri.parse(params.uri);
   const key = uri.toString();
 
-  // server sends 1-based line numbers but VS Code Range expects 0-based indices
   const ranges = params.ranges.map(
-    (r) => new Range(r.start - 1, 0, r.end - 1, Number.MAX_SAFE_INTEGER),
+    (r) => new Range(r.start, 0, r.end, Number.MAX_SAFE_INTEGER),
   );
   inactiveRangesByUri.set(key, ranges);
 
@@ -218,9 +219,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
               : workspace.workspaceFolders?.[0];
 
             if (!targetWorkspace || targetWorkspace.uri.scheme !== "file") {
-              window.showErrorMessage(
-                "GSCLSP: Open a local workspace folder to save gsclsp.config.json",
-              );
+              window.showErrorMessage("GSCLSP: Open a local workspace folder to save gsclsp.config.json");
               return;
             }
 
@@ -255,9 +254,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
             } catch (error) {
               const message =
                 error instanceof Error ? error.message : String(error);
-              window.showErrorMessage(
-                `GSCLSP: Failed to write gsclsp.config.json: ${message}`,
-              );
+              window.showErrorMessage(`GSCLSP: Failed to write gsclsp.config.json: ${message}`);
             }
 
             return new Promise((resolve) => setTimeout(resolve, 2000));

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -130,11 +130,8 @@ async function selectTargetGameCommand(): Promise<void> {
   const config = await readWorkspaceConfig(folder);
   config.game = chosen;
   await writeWorkspaceConfig(folder, config);
-  await client.sendNotification("custom/updateTargetGame", {
-    targetGame: chosen,
-  });
   await updateStatusBar();
-  window.showInformationMessage(`GSCLSP: Target game set to \"${chosen.toUpperCase()}\"`);
+  window.showInformationMessage(`GSCLSP: Target game set to "${chosen.toUpperCase()}"`);
 }
 
 interface InactiveRegionsParams {
@@ -251,10 +248,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
                 JSON.stringify(config, null, 2),
                 "utf8",
               );
-
-              await client.sendNotification("custom/updateDumpPath", {
-                path: newPath,
-              });
 
               window.showInformationMessage(
                 `GSCLSP: Updated ${configPath}`,

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -128,6 +128,9 @@ async function selectTargetGameCommand(): Promise<void> {
   const config = await readWorkspaceConfig(folder);
   config.game = chosen;
   await writeWorkspaceConfig(folder, config);
+  await client.sendNotification("custom/updateTargetGame", {
+    targetGame: chosen,
+  });
   await updateStatusBar();
   window.showInformationMessage(`GSCLSP: Target game set to \"${chosen.toUpperCase()}\"`);
 }
@@ -148,8 +151,9 @@ function handleInactiveRegions(params: InactiveRegionsParams): void {
   const uri = Uri.parse(params.uri);
   const key = uri.toString();
 
+  // server sends 1-based line numbers but VS Code Range expects 0-based indices
   const ranges = params.ranges.map(
-    (r) => new Range(r.start, 0, r.end, Number.MAX_SAFE_INTEGER),
+    (r) => new Range(r.start - 1, 0, r.end - 1, Number.MAX_SAFE_INTEGER),
   );
   inactiveRangesByUri.set(key, ranges);
 
@@ -339,6 +343,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const configWatcher = workspace.createFileSystemWatcher("**/gsclsp.config.json");
   configWatcher.onDidChange(() => updateStatusBar());
   configWatcher.onDidCreate(() => updateStatusBar());
+  configWatcher.onDidDelete(() => updateStatusBar());
   context.subscriptions.push(configWatcher);
 
   inactiveDecoration = window.createTextEditorDecorationType({
@@ -349,6 +354,12 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   context.subscriptions.push(
     client.onNotification("custom/inactiveRegions", handleInactiveRegions),
+  );
+
+  context.subscriptions.push(
+    workspace.onDidCloseTextDocument((doc) => {
+      inactiveRangesByUri.delete(doc.uri.toString());
+    }),
   );
 
   context.subscriptions.push(

--- a/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
@@ -55,12 +55,17 @@ public partial class GscDiagnosticsHandler
     public void PublishInactiveRegions(DocumentUri uri, string text)
     {
         var lines = text.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
-        var ranges = GscInactiveRegionAnalyzer.Analyze(lines, _indexer.CurrentGame);
+        var ifdefRanges = GscInactiveRegionAnalyzer.Analyze(lines, _indexer.CurrentGame);
+
+        var lexed = new GSCLSP.Lexer.GscLexer().Lex(text);
+        var deadCode = GscDeadCodeAnalyzer.Analyze(lines, lexed.Tokens);
+
+        var combined = ifdefRanges.Concat(deadCode.DeadRanges);
 
         _languageServer.SendNotification("custom/inactiveRegions", new
         {
             uri = uri.ToString(),
-            ranges = ranges.Select(r => new { start = r.StartLine, end = r.EndLine }).ToArray()
+            ranges = combined.Select(r => new { start = r.StartLine, end = r.EndLine }).ToArray()
         });
     }
 

--- a/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
@@ -9,16 +9,35 @@ using static GSCLSP.Core.Models.RegexPatterns;
 
 namespace GSCLSP.Server.Handlers;
 
-public partial class GscDiagnosticsHandler(GscIndexer indexer, ILanguageServerFacade languageServer)
+public partial class GscDiagnosticsHandler
 {
     public const string UnresolvedFunctionDiagnosticCode = "gsclsp.unresolvedFunction";
     public const string RecursiveFunctionWarningCode = "gsclsp.recursiveFunction";
     public const string MissingSemicolonWarningCode = "gsclsp.missingSemicolon";
     public const string InvalidBuiltinArgCountDiagnosticCode = "gsclsp.invalidBuiltinArgCount";
 
-    private readonly GscIndexer _indexer = indexer;
-    private readonly GscDiagnosticsAnalyzer _diagnosticsAnalyzer = new(indexer);
-    private readonly ILanguageServerFacade _languageServer = languageServer;
+    private readonly GscIndexer _indexer;
+    private readonly GscDiagnosticsAnalyzer _diagnosticsAnalyzer;
+    private readonly ILanguageServerFacade _languageServer;
+    private readonly GscDocumentStore _documentStore;
+
+    public GscDiagnosticsHandler(GscIndexer indexer, ILanguageServerFacade languageServer, GscDocumentStore documentStore)
+    {
+        _indexer = indexer;
+        _languageServer = languageServer;
+        _documentStore = documentStore;
+        _diagnosticsAnalyzer = new GscDiagnosticsAnalyzer(indexer);
+
+        _indexer.GameChanged += _ => RepublishAllOpenDocuments();
+    }
+
+    private void RepublishAllOpenDocuments()
+    {
+        foreach (var (uri, text) in _documentStore.OpenDocuments)
+        {
+            _ = PublishAsync(uri, text, CancellationToken.None);
+        }
+    }
 
     public async Task PublishAsync(DocumentUri uri, string text, CancellationToken cancellationToken)
     {
@@ -28,6 +47,20 @@ public partial class GscDiagnosticsHandler(GscIndexer indexer, ILanguageServerFa
         {
             Uri = uri,
             Diagnostics = new Container<Diagnostic>(diagnostics)
+        });
+
+        PublishInactiveRegions(uri, text);
+    }
+
+    public void PublishInactiveRegions(DocumentUri uri, string text)
+    {
+        var lines = text.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+        var ranges = GscInactiveRegionAnalyzer.Analyze(lines, _indexer.CurrentGame);
+
+        _languageServer.SendNotification("custom/inactiveRegions", new
+        {
+            uri = uri.ToString(),
+            ranges = ranges.Select(r => new { start = r.StartLine, end = r.EndLine }).ToArray()
         });
     }
 

--- a/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
@@ -37,13 +37,13 @@ public class GscDiagnosticsHandler
         var cancellationTokenSource = new CancellationTokenSource();
         var previous = Interlocked.Exchange(ref _republishCancellationTokenSource, cancellationTokenSource);
         previous?.Cancel();
-        previous?.Dispose();
 
-        _ = RepublishAllOpenDocuments(cancellationTokenSource.Token);
+        _ = RepublishAllOpenDocumentsAsync(cancellationTokenSource);
     }
 
-    private async Task RepublishAllOpenDocuments(CancellationToken cancellationToken)
+    private async Task RepublishAllOpenDocumentsAsync(CancellationTokenSource cancellationTokenSource)
     {
+        var cancellationToken = cancellationTokenSource.Token;
         var tasks = _documentStore.OpenDocuments
             .Select(document => RepublishDocumentAsync(document.Key, document.Value, cancellationToken))
             .ToArray();
@@ -54,6 +54,10 @@ public class GscDiagnosticsHandler
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+        }
+        finally
+        {
+            cancellationTokenSource.Dispose();
         }
     }
 
@@ -68,7 +72,7 @@ public class GscDiagnosticsHandler
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"GSCLSP: failed to republish diagnostics for '{uri}': {ex}");
+            await Console.Error.WriteLineAsync($"GSCLSP: failed to republish diagnostics for '{uri}': {ex}");
         }
     }
 

--- a/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
@@ -21,15 +21,13 @@ public class GscDiagnosticsHandler
     private readonly GscDiagnosticsAnalyzer _diagnosticsAnalyzer;
     private readonly ILanguageServerFacade _languageServer;
     private readonly GscDocumentStore _documentStore;
-    private readonly ILogger<GscDiagnosticsHandler> _logger;
     private CancellationTokenSource? _republishCancellationTokenSource;
 
-    public GscDiagnosticsHandler(GscIndexer indexer, ILanguageServerFacade languageServer, GscDocumentStore documentStore, ILogger<GscDiagnosticsHandler> logger)
+    public GscDiagnosticsHandler(GscIndexer indexer, ILanguageServerFacade languageServer, GscDocumentStore documentStore)
     {
         _indexer = indexer;
         _languageServer = languageServer;
         _documentStore = documentStore;
-        _logger = logger;
         _diagnosticsAnalyzer = new GscDiagnosticsAnalyzer(indexer);
 
         _indexer.GameChanged += _ => StartRepublishAllOpenDocuments();
@@ -75,7 +73,6 @@ public class GscDiagnosticsHandler
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to republish diagnostics for '{Uri}'", uri);
         }
     }
 

--- a/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
@@ -1,6 +1,7 @@
 using GSCLSP.Core.Indexing;
 using GSCLSP.Core.Diagnostics;
 using GSCLSP.Core.Models;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -20,13 +21,15 @@ public class GscDiagnosticsHandler
     private readonly GscDiagnosticsAnalyzer _diagnosticsAnalyzer;
     private readonly ILanguageServerFacade _languageServer;
     private readonly GscDocumentStore _documentStore;
+    private readonly ILogger<GscDiagnosticsHandler> _logger;
     private CancellationTokenSource? _republishCancellationTokenSource;
 
-    public GscDiagnosticsHandler(GscIndexer indexer, ILanguageServerFacade languageServer, GscDocumentStore documentStore)
+    public GscDiagnosticsHandler(GscIndexer indexer, ILanguageServerFacade languageServer, GscDocumentStore documentStore, ILogger<GscDiagnosticsHandler> logger)
     {
         _indexer = indexer;
         _languageServer = languageServer;
         _documentStore = documentStore;
+        _logger = logger;
         _diagnosticsAnalyzer = new GscDiagnosticsAnalyzer(indexer);
 
         _indexer.GameChanged += _ => StartRepublishAllOpenDocuments();
@@ -72,7 +75,7 @@ public class GscDiagnosticsHandler
         }
         catch (Exception ex)
         {
-            await Console.Error.WriteLineAsync($"GSCLSP: failed to republish diagnostics for '{uri}': {ex}");
+            _logger.LogError(ex, "Failed to republish diagnostics for '{Uri}'", uri);
         }
     }
 

--- a/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
@@ -9,7 +9,7 @@ using static GSCLSP.Core.Models.RegexPatterns;
 
 namespace GSCLSP.Server.Handlers;
 
-public partial class GscDiagnosticsHandler
+public class GscDiagnosticsHandler
 {
     public const string UnresolvedFunctionDiagnosticCode = "gsclsp.unresolvedFunction";
     public const string RecursiveFunctionWarningCode = "gsclsp.recursiveFunction";
@@ -20,6 +20,7 @@ public partial class GscDiagnosticsHandler
     private readonly GscDiagnosticsAnalyzer _diagnosticsAnalyzer;
     private readonly ILanguageServerFacade _languageServer;
     private readonly GscDocumentStore _documentStore;
+    private CancellationTokenSource? _republishCancellationTokenSource;
 
     public GscDiagnosticsHandler(GscIndexer indexer, ILanguageServerFacade languageServer, GscDocumentStore documentStore)
     {
@@ -28,14 +29,46 @@ public partial class GscDiagnosticsHandler
         _documentStore = documentStore;
         _diagnosticsAnalyzer = new GscDiagnosticsAnalyzer(indexer);
 
-        _indexer.GameChanged += _ => RepublishAllOpenDocuments();
+        _indexer.GameChanged += _ => StartRepublishAllOpenDocuments();
     }
 
-    private void RepublishAllOpenDocuments()
+    private void StartRepublishAllOpenDocuments()
     {
-        foreach (var (uri, text) in _documentStore.OpenDocuments)
+        var cancellationTokenSource = new CancellationTokenSource();
+        var previous = Interlocked.Exchange(ref _republishCancellationTokenSource, cancellationTokenSource);
+        previous?.Cancel();
+        previous?.Dispose();
+
+        _ = RepublishAllOpenDocuments(cancellationTokenSource.Token);
+    }
+
+    private async Task RepublishAllOpenDocuments(CancellationToken cancellationToken)
+    {
+        var tasks = _documentStore.OpenDocuments
+            .Select(document => RepublishDocumentAsync(document.Key, document.Value, cancellationToken))
+            .ToArray();
+
+        try
         {
-            _ = PublishAsync(uri, text, CancellationToken.None);
+            await Task.WhenAll(tasks);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task RepublishDocumentAsync(DocumentUri uri, string text, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await PublishAsync(uri, text, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"GSCLSP: failed to republish diagnostics for '{uri}': {ex}");
         }
     }
 
@@ -49,23 +82,30 @@ public partial class GscDiagnosticsHandler
             Diagnostics = new Container<Diagnostic>(diagnostics)
         });
 
-        PublishInactiveRegions(uri, text);
+        await PublishInactiveRegionsAsync(uri, text, cancellationToken);
     }
 
-    public void PublishInactiveRegions(DocumentUri uri, string text)
+    public async Task PublishInactiveRegionsAsync(DocumentUri uri, string text, CancellationToken cancellationToken)
     {
-        var lines = text.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
-        var ifdefRanges = GscInactiveRegionAnalyzer.Analyze(lines, _indexer.CurrentGame);
+        var ranges = await Task.Run(() =>
+        {
+            var lines = text.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+            var lexed = new GSCLSP.Lexer.GscLexer().Lex(text);
+            var ifdefRanges = GscInactiveRegionAnalyzer.Analyze(lines, _indexer.CurrentGame);
+            var deadCode = GscDeadCodeAnalyzer.Analyze(lines, lexed.Tokens);
 
-        var lexed = new GSCLSP.Lexer.GscLexer().Lex(text);
-        var deadCode = GscDeadCodeAnalyzer.Analyze(lines, lexed.Tokens);
+            return ifdefRanges
+                .Concat(deadCode.DeadRanges)
+                .Select(r => new { start = r.StartLine, end = r.EndLine })
+                .ToArray();
+        }, cancellationToken);
 
-        var combined = ifdefRanges.Concat(deadCode.DeadRanges);
+        cancellationToken.ThrowIfCancellationRequested();
 
         _languageServer.SendNotification("custom/inactiveRegions", new
         {
             uri = uri.ToString(),
-            ranges = combined.Select(r => new { start = r.StartLine, end = r.EndLine }).ToArray()
+            ranges
         });
     }
 

--- a/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
@@ -71,7 +71,7 @@ public class GscDiagnosticsHandler
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
         }
-        catch (Exception ex)
+        catch (Exception)
         {
         }
     }

--- a/GSCLSP.Server/Handlers/GscDocumentSyncHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDocumentSyncHandler.cs
@@ -15,6 +15,7 @@ public class GscDocumentStore
     public void Update(DocumentUri uri, string text) => _documents[uri] = text;
     public void Remove(DocumentUri uri) => _documents.TryRemove(uri, out _);
     public string? Get(DocumentUri uri) => _documents.TryGetValue(uri, out var text) ? text : null;
+    public IEnumerable<KeyValuePair<DocumentUri, string>> OpenDocuments => _documents;
 }
 
 public class GscDocumentSyncHandler(GscDocumentStore store, GscDiagnosticsHandler diagnosticsHandler) : TextDocumentSyncHandlerBase

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -1,4 +1,5 @@
-﻿using GSCLSP.Core.Indexing;
+﻿using GSCLSP.Core.Diagnostics;
+using GSCLSP.Core.Indexing;
 using GSCLSP.Core.Parsing;
 using GSCLSP.Lexer;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -230,6 +231,9 @@ public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore docume
         var macro = _indexer.ResolveMacro(filePath, identifier);
         if (macro == null) return null;
 
+        // a preprocessor may have a #ifdef define #else define #endif, which means hover should use the active
+        macro = GetActveMacroDefinition(filePath, identifier, macro);
+
         string[] macroFileLines = _indexer.GetFileLines(macro.FilePath);
         var comment = GetLeadingComment(macroFileLines, macro.Line - 1);
 
@@ -244,5 +248,23 @@ public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore docume
 
         var content = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
         return new Hover { Contents = new MarkedStringsOrMarkupContent(content) };
+    }
+
+    private MacroDefinition GetActveMacroDefinition(string filePath, string identifier, MacroDefinition fallback)
+    {
+        var localMatches = GscIndexer.GetFileMacros(filePath)
+            .Where(m => m.Name.Equals(identifier, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (localMatches.Count <= 1) return fallback;
+
+        var inactiveRanges = GscInactiveRegionAnalyzer.Analyze(_indexer.GetFileLines(filePath), _indexer.CurrentGame);
+
+        var active = localMatches.FirstOrDefault(m =>
+        {
+            int zeroBased = m.Line - 1;
+            return !inactiveRanges.Any(r => zeroBased >= r.StartLine && zeroBased <= r.EndLine);
+        });
+
+        return active ?? fallback;
     }
 }

--- a/GSCLSP.Server/Program.cs
+++ b/GSCLSP.Server/Program.cs
@@ -43,8 +43,7 @@ var server = await LanguageServer.From(options =>
 
             if (!string.IsNullOrEmpty(workspacePath))
             {
-                var serverIndexer = server.Services.GetService<GscIndexer>();
-                serverIndexer?.IndexWorkspace(workspacePath);
+                indexer.IndexWorkspace(workspacePath);
             }
             else
             {


### PR DESCRIPTION
the title is a mouthful but it sums up pretty much the changes here.
1. adds "GSC Target Game" selection at the bottom of the UI
2. will highlight "inactive regions" within preprocessors like ifdef for specific game conditions
3. will highlight "inactive regions" within early returns
4. adds builtin function/method loading per target game, and on changing via UI

for the future, it would be ideal to stuff GSC dumps per target game so its not just one 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Early-return warnings for unreachable code (with mute controls)
  * Inactive-region detection and editor decorations driven from the server
  * Workspace target-game selection in the status bar plus "GSC: Select Target Game" command
  * Built-in symbol loading with per-game caching, name-only fallbacks and background refresh
  * Server republishes diagnostics when the configured game changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->