### PR TITLE
feature: add changing of gsc-tool source

### DIFF
--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -117,7 +117,7 @@ public partial class GscIndexer
         {
             if (File.Exists(cacheFile))
             {
-                Console.Error.WriteLine($"GSCLSP: Found existing cache. Loading...");
+                Console.Error.WriteLine($"GSCLSP: Loading existing GSC dump cache...");
                 LoadGlobalIndex(cacheFile);
             }
             else
@@ -151,7 +151,7 @@ public partial class GscIndexer
             }
         }
 
-        Console.Error.WriteLine($"GSCLSP: Indexer loaded {_symbols.Count} symbols from JSON.");
+        Console.Error.WriteLine($"GSCLSP: Indexer loaded {_symbols.Count} GSC symbols from JSON.");
     }
 
     private void ParseFile(string path)
@@ -993,7 +993,7 @@ public partial class GscIndexer
             Console.Error.WriteLine("GSCLSP: gsclsp.config.json not found. Dump index disabled unless configured.");
         }
 
-        LoadConfiguredBuiltIns(hasWorkspaceConfig, workspaceConfig?.Game);
+        LoadConfiguredBuiltIns(hasWorkspaceConfig, workspaceConfig?.Game, workspaceConfig?.GscToolRepository);
         UpdateDumpPath(resolvedDumpPath);
     }
 
@@ -1016,7 +1016,7 @@ public partial class GscIndexer
 
     private static readonly TimeSpan GscToolCacheMaxAge = TimeSpan.FromDays(7);
 
-    private void LoadConfiguredBuiltIns(bool hasWorkspaceConfig, string? workspaceGame)
+    private void LoadConfiguredBuiltIns(bool hasWorkspaceConfig, string? workspaceGame, string? workspaceGscToolRepository)
     {
         var game = ResolveGameValue(hasWorkspaceConfig, workspaceGame);
         var normalizedGame = string.IsNullOrWhiteSpace(game)
@@ -1042,22 +1042,32 @@ public partial class GscIndexer
 
         if (GscToolBuiltInsLoader.IsSupported(normalizedGame))
         {
-            var cached = GscToolBuiltInsLoader.TryLoadFromCache(normalizedGame);
+            var source = ResolveGscToolSource(workspaceGscToolRepository);
+            var sourceLabel = source.IsDefault ? "" : $" (from {source.DisplayName})";
+
+            var cached = GscToolBuiltInsLoader.TryLoadFromCache(normalizedGame, source);
             if (cached != null)
             {
-                BuiltIns.LoadNameOnlyBuiltIns(cached.Functions, cached.Methods, cached.Tokens);
-                Console.Error.WriteLine($"GSCLSP: Loaded cached builtins for game '{normalizedGame}'.");
-                if (gameChanged) GameChanged?.Invoke(normalizedGame);
+                var previousFunctions = SnapshotBuiltInNames(SymbolType.Function);
+                var previousMethods = SnapshotBuiltInNames(SymbolType.Method);
 
-                if (GscToolBuiltInsLoader.IsCacheStale(normalizedGame, GscToolCacheMaxAge))
-                    _ = RefreshGscToolBuiltInsAsync(normalizedGame);
+                BuiltIns.LoadNameOnlyBuiltIns(cached.Functions, cached.Methods, cached.Tokens);
+                Console.Error.WriteLine($"GSCLSP: Loaded cached builtins for game '{normalizedGame}'{sourceLabel}.");
+
+                var builtInsChanged = !BuiltInNamesEqual(previousFunctions, cached.Functions)
+                                   || !BuiltInNamesEqual(previousMethods, cached.Methods);
+
+                if (gameChanged || builtInsChanged) GameChanged?.Invoke(normalizedGame);
+
+                if (GscToolBuiltInsLoader.IsCacheStale(normalizedGame, source, GscToolCacheMaxAge))
+                    _ = RefreshGscToolBuiltInsAsync(normalizedGame, source);
             }
             else
             {
                 BuiltIns.LoadNameOnlyBuiltIns([], [], []);
-                Console.Error.WriteLine($"GSCLSP: No cache for '{normalizedGame}', fetching from gsc-tool...");
+                Console.Error.WriteLine($"GSCLSP: No cache for '{normalizedGame}'{sourceLabel}, fetching from gsc-tool...");
                 if (gameChanged) GameChanged?.Invoke(normalizedGame);
-                _ = RefreshGscToolBuiltInsAsync(normalizedGame);
+                _ = RefreshGscToolBuiltInsAsync(normalizedGame, source);
             }
             return;
         }
@@ -1078,33 +1088,42 @@ public partial class GscIndexer
         if (gameChanged) GameChanged?.Invoke(normalizedGame);
     }
 
-    private async Task RefreshGscToolBuiltInsAsync(string game)
+    private async Task RefreshGscToolBuiltInsAsync(string game, GscToolSource source)
     {
-        var fetched = await GscToolBuiltInsLoader.FetchAsync(game);
+        var fetched = await GscToolBuiltInsLoader.FetchAsync(game, source);
         if (fetched == null)
         {
-            await Console.Error.WriteLineAsync($"GSCLSP: gsc-tool fetch for '{game}' failed or unsupported.");
+            await Console.Error.WriteLineAsync($"GSCLSP: gsc-tool fetch for '{game}' from {source.DisplayName} failed or unsupported.");
             return;
         }
 
         if (!string.Equals(CurrentGame, game, StringComparison.OrdinalIgnoreCase))
             return;
 
-        var previousFunctions = BuiltIns.GetAll()
-            .Where(symbol => symbol.Type == SymbolType.Function)
-            .Select(symbol => symbol.Name)
-            .ToArray();
-        var previousMethods = BuiltIns.GetAll(preferMethodsFirst: true)
-            .Where(symbol => symbol.Type == SymbolType.Method)
-            .Select(symbol => symbol.Name)
-            .ToArray();
+        var previousFunctions = SnapshotBuiltInNames(SymbolType.Function);
+        var previousMethods = SnapshotBuiltInNames(SymbolType.Method);
         var builtInsChanged = !BuiltInNamesEqual(previousFunctions, fetched.Functions)
             || !BuiltInNamesEqual(previousMethods, fetched.Methods);
 
         BuiltIns.LoadNameOnlyBuiltIns(fetched.Functions, fetched.Methods, fetched.Tokens);
-        await Console.Error.WriteLineAsync($"GSCLSP: Refreshed gsc-tool built-ins for game '{game}'.");
+        await Console.Error.WriteLineAsync($"GSCLSP: Refreshed built-ins for game '{game}' ({source.DisplayName})");
         if (builtInsChanged)
             GameChanged?.Invoke(game);
+    }
+
+    private string[] SnapshotBuiltInNames(SymbolType symbolType) =>
+        [..BuiltIns.GetAll().Where(s => s.Type == symbolType).Select(s => s.Name)];
+
+    private static GscToolSource ResolveGscToolSource(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return GscToolSource.Default;
+
+        if (GscToolSource.TryParse(raw, out var source))
+            return source;
+
+        Console.Error.WriteLine($"GSCLSP: invalid gsc_tool_repository '{raw}', falling back to {GscToolSource.Default.DisplayName}.");
+        return GscToolSource.Default;
     }
 
     private static bool BuiltInNamesEqual(IEnumerable<string> left, IEnumerable<string> right)
@@ -1121,7 +1140,7 @@ public partial class GscIndexer
         return "iw4";
     }
 
-    private sealed record WorkspaceConfig(string? DumpPath, string? Game);
+    private sealed record WorkspaceConfig(string? DumpPath, string? Game, string? GscToolRepository);
 
     private static (bool HasConfigFile, WorkspaceConfig? Config) TryReadWorkspaceConfig(string? workspacePath)
     {
@@ -1150,6 +1169,7 @@ public partial class GscIndexer
 
             string? dumpPath = null;
             string? game = null;
+            string? gscToolRepository = null;
 
             if (root.TryGetProperty("dumpPath", out var directDumpPath) && directDumpPath.ValueKind == JsonValueKind.String)
                 dumpPath = directDumpPath.GetString();
@@ -1157,7 +1177,10 @@ public partial class GscIndexer
             if (root.TryGetProperty("game", out var gameProperty) && gameProperty.ValueKind == JsonValueKind.String)
                 game = gameProperty.GetString();
 
-            return new WorkspaceConfig(dumpPath, game);
+            if (root.TryGetProperty("gsc_tool_repository", out var gscToolRepositoryProperty) && gscToolRepositoryProperty.ValueKind == JsonValueKind.String)
+                gscToolRepository = gscToolRepositoryProperty.GetString();
+
+            return new WorkspaceConfig(dumpPath, game, gscToolRepository);
         }
         catch { }
 

--- a/GSCLSP.Core/Models/RegexPatterns.cs
+++ b/GSCLSP.Core/Models/RegexPatterns.cs
@@ -55,4 +55,10 @@ public partial class RegexPatterns
 
     [GeneratedRegex(@"\{\s*0x(?<id>[0-9A-Fa-f]+)\s*,\s*""(?<name>[^""]+)""\s*\}", RegexOptions.Compiled)]
     public static partial Regex GscToolRegex();
+
+    [GeneratedRegex(@"^[A-Za-z0-9._-]+$")]
+    public static partial Regex GitHubSegmentRegex();
+
+    [GeneratedRegex(@"^[A-Za-z0-9._/\-]+$")]
+    public static partial Regex GitHubBranchRegex();
 }

--- a/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
+++ b/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
@@ -15,7 +15,6 @@ public static class GscToolBuiltInsLoader
 
     private static readonly HttpClient http = new()
     {
-        BaseAddress = new Uri("https://raw.githubusercontent.com/xensik/gsc-tool/refs/heads/dev/src/gsc/engine/"),
         Timeout = TimeSpan.FromSeconds(120)
     };
 
@@ -32,14 +31,17 @@ public static class GscToolBuiltInsLoader
         return Path.Combine(root, $"{game.ToLowerInvariant()}_gsctool.json");
     }
 
-    public static bool IsCacheStale(string game, TimeSpan maxAge)
+    public static bool IsCacheStale(string game, GscToolSource source, TimeSpan maxAge)
     {
         var path = CachePath(game);
         if (!File.Exists(path)) return true;
-        return DateTime.UtcNow - File.GetLastWriteTimeUtc(path) > maxAge;
+        if (DateTime.UtcNow - File.GetLastWriteTimeUtc(path) > maxAge) return true;
+
+        var cachedSource = TryReadCachedSource(path);
+        return !source.Equals(cachedSource);
     }
 
-    public static NameLists? TryLoadFromCache(string game)
+    public static NameLists? TryLoadFromCache(string game, GscToolSource source)
     {
         try
         {
@@ -47,6 +49,9 @@ public static class GscToolBuiltInsLoader
             if (!File.Exists(path)) return null;
 
             using var doc = JsonDocument.Parse(File.ReadAllText(path));
+            var cachedSource = ReadSourceElement(doc.RootElement) ?? GscToolSource.Default;
+            if (!source.Equals(cachedSource)) return null;
+
             var functions = ReadArray(doc.RootElement, "functions");
             var methods = ReadArray(doc.RootElement, "methods");
             var tokens = ReadArray(doc.RootElement, "tokens");
@@ -59,30 +64,31 @@ public static class GscToolBuiltInsLoader
         }
     }
 
-    public static async Task<NameLists?> FetchAsync(string game, CancellationToken ct = default)
+    public static async Task<NameLists?> FetchAsync(string game, GscToolSource source, CancellationToken ct = default)
     {
         var key = game.Trim().ToLowerInvariant();
         if (!IsSupported(key)) return null;
 
         try
         {
-            var funcTask = TryGetFirstAvailableAsync(ct,
+            var baseUrl = source.EngineDirectoryUrl;
+            var funcTask = TryGetFirstAvailableAsync(ct, baseUrl,
                 $"{key}_func.cpp",
                 $"{key}_pc_func.cpp");
-            var methTask = TryGetFirstAvailableAsync(ct,
+            var methTask = TryGetFirstAvailableAsync(ct, baseUrl,
                 $"{key}_meth.cpp",
                 $"{key}_pc_meth.cpp");
-            var tokTask = TryGetFirstAvailableAsync(ct,
+            var tokTask = TryGetFirstAvailableAsync(ct, baseUrl,
                 $"{key}_token.cpp",
                 $"{key}_pc_token.cpp");
 
-            var source = await Task.WhenAll(funcTask, methTask, tokTask);
+            var fetched = await Task.WhenAll(funcTask, methTask, tokTask);
 
-            if (source.All(string.IsNullOrEmpty)) return null;
+            if (fetched.All(string.IsNullOrEmpty)) return null;
 
-            var funcSource = source[0];
-            var methSource = source[1];
-            var tokSource = source[2];
+            var funcSource = fetched[0];
+            var methSource = fetched[1];
+            var tokSource = fetched[2];
 
             var functions = ParseNames(funcSource);
             var methods = ParseNames(methSource);
@@ -93,7 +99,7 @@ public static class GscToolBuiltInsLoader
 
             if (functions.Count == 0 && methods.Count == 0 && tokens.Count == 0) return null;
 
-            SaveCache(key, functions, methods, tokens);
+            SaveCache(key, source, functions, methods, tokens);
             return new NameLists(functions, methods, tokens);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -106,12 +112,12 @@ public static class GscToolBuiltInsLoader
         }
     }
 
-    private static async Task<string?> TryGetFirstAvailableAsync(CancellationToken ct, params string[] urls)
+    private static async Task<string?> TryGetFirstAvailableAsync(CancellationToken ct, string baseUrl, params string[] paths)
     {
-        foreach (var url in urls)
+        foreach (var p in paths)
         {
             ct.ThrowIfCancellationRequested();
-            try { return await http.GetStringAsync(url, ct); }
+            try { return await http.GetStringAsync(baseUrl + p, ct); }
             catch (OperationCanceledException) { throw; }
             catch { }
         }
@@ -150,7 +156,40 @@ public static class GscToolBuiltInsLoader
         return result;
     }
 
-    private static void SaveCache(string game, IEnumerable<string> functions, IEnumerable<string> methods, IEnumerable<string> tokens /* Unused */)
+    private static GscToolSource? TryReadCachedSource(string path)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+            return ReadSourceElement(doc.RootElement) ?? GscToolSource.Default;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static GscToolSource? ReadSourceElement(JsonElement root)
+    {
+        if (!root.TryGetProperty("source", out var src) || src.ValueKind != JsonValueKind.Object)
+            return null;
+        if (!src.TryGetProperty("owner", out var owner) || owner.ValueKind != JsonValueKind.String)
+            return null;
+        if (!src.TryGetProperty("repo", out var repo) || repo.ValueKind != JsonValueKind.String)
+            return null;
+        if (!src.TryGetProperty("branch", out var branch) || branch.ValueKind != JsonValueKind.String)
+            return null;
+
+        var ownerStr = owner.GetString();
+        var repoStr = repo.GetString();
+        var branchStr = branch.GetString();
+        if (string.IsNullOrWhiteSpace(ownerStr) || string.IsNullOrWhiteSpace(repoStr) || string.IsNullOrWhiteSpace(branchStr))
+            return null;
+
+        return new GscToolSource(ownerStr, repoStr, branchStr);
+    }
+
+    private static void SaveCache(string game, GscToolSource source, IEnumerable<string> functions, IEnumerable<string> methods, IEnumerable<string> tokens /* Unused */)
     {
         try
         {
@@ -158,7 +197,12 @@ public static class GscToolBuiltInsLoader
             var dir = Path.GetDirectoryName(path);
             if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
 
-            var payload = new { functions = functions.ToArray(), methods = methods.ToArray() };
+            var payload = new
+            {
+                source = new { owner = source.Owner, repo = source.Repo, branch = source.Branch },
+                functions = functions.ToArray(),
+                methods = methods.ToArray()
+            };
             File.WriteAllText(path, JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
         }
         catch { }

--- a/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
+++ b/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
@@ -99,7 +99,7 @@ public static class GscToolBuiltInsLoader
 
             if (functions.Count == 0 && methods.Count == 0 && tokens.Count == 0) return null;
 
-            SaveCache(key, source, functions, methods, tokens);
+            SaveCache(key, source, functions, methods);
             return new NameLists(functions, methods, tokens);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -189,7 +189,7 @@ public static class GscToolBuiltInsLoader
         return new GscToolSource(ownerStr, repoStr, branchStr);
     }
 
-    private static void SaveCache(string game, GscToolSource source, IEnumerable<string> functions, IEnumerable<string> methods, IEnumerable<string> tokens /* Unused */)
+    private static void SaveCache(string game, GscToolSource source, IEnumerable<string> functions, IEnumerable<string> methods)
     {
         try
         {

--- a/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
+++ b/GSCLSP.Core/Tools/GscToolBuiltInsLoader.cs
@@ -71,14 +71,14 @@ public static class GscToolBuiltInsLoader
 
         try
         {
-            var baseUrl = source.EngineDirectoryUrl;
-            var funcTask = TryGetFirstAvailableAsync(ct, baseUrl,
+            var baseUri = source.EngineDirectoryUri;
+            var funcTask = TryGetFirstAvailableAsync(ct, baseUri,
                 $"{key}_func.cpp",
                 $"{key}_pc_func.cpp");
-            var methTask = TryGetFirstAvailableAsync(ct, baseUrl,
+            var methTask = TryGetFirstAvailableAsync(ct, baseUri,
                 $"{key}_meth.cpp",
                 $"{key}_pc_meth.cpp");
-            var tokTask = TryGetFirstAvailableAsync(ct, baseUrl,
+            var tokTask = TryGetFirstAvailableAsync(ct, baseUri,
                 $"{key}_token.cpp",
                 $"{key}_pc_token.cpp");
 
@@ -112,12 +112,12 @@ public static class GscToolBuiltInsLoader
         }
     }
 
-    private static async Task<string?> TryGetFirstAvailableAsync(CancellationToken ct, string baseUrl, params string[] paths)
+    private static async Task<string?> TryGetFirstAvailableAsync(CancellationToken ct, Uri baseUri, params string[] paths)
     {
         foreach (var p in paths)
         {
             ct.ThrowIfCancellationRequested();
-            try { return await http.GetStringAsync(baseUrl + p, ct); }
+            try { return await http.GetStringAsync(new Uri(baseUri, p), ct); }
             catch (OperationCanceledException) { throw; }
             catch { }
         }

--- a/GSCLSP.Core/Tools/GscToolSource.cs
+++ b/GSCLSP.Core/Tools/GscToolSource.cs
@@ -32,9 +32,11 @@ public sealed partial record GscToolSource(string Owner, string Repo, string Bra
         var repo = TrimDotGit(segments[1]);
         var branch = Default.Branch;
 
-        if (segments.Length >= 4 &&
-            (segments[2].Equals("tree", StringComparison.OrdinalIgnoreCase) ||
-             segments[2].Equals("blob", StringComparison.OrdinalIgnoreCase)))
+        if (segments.Length >= 4 && segments[2].Equals("tree", StringComparison.OrdinalIgnoreCase))
+        {
+            branch = Uri.UnescapeDataString(string.Join("/", segments.Skip(3)));
+        }
+        else if (segments.Length >= 4 && segments[2].Equals("blob", StringComparison.OrdinalIgnoreCase))
         {
             branch = Uri.UnescapeDataString(segments[3]);
         }

--- a/GSCLSP.Core/Tools/GscToolSource.cs
+++ b/GSCLSP.Core/Tools/GscToolSource.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+
+namespace GSCLSP.Core.Tools;
+
+public sealed partial record GscToolSource(string Owner, string Repo, string Branch)
+{
+    public static readonly GscToolSource Default = new("xensik", "gsc-tool", "dev");
+
+    public string EngineDirectoryUrl =>
+        $"https://raw.githubusercontent.com/{Owner}/{Repo}/refs/heads/{Branch}/src/gsc/engine/";
+
+    public bool IsDefault => Equals(Default);
+
+    public string DisplayName => $"{Owner}/{Repo}@{Branch}";
+
+    public static bool TryParse(string? raw, out GscToolSource source)
+    {
+        source = Default;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+
+        if (!Uri.TryCreate(raw.Trim(), UriKind.Absolute, out var uri))
+            return false;
+
+        if (!uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase) &&
+            !uri.Host.Equals("www.github.com", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 2) return false;
+
+        var owner = segments[0];
+        var repo = TrimDotGit(segments[1]);
+        var branch = Default.Branch;
+
+        if (segments.Length >= 4 &&
+            (segments[2].Equals("tree", StringComparison.OrdinalIgnoreCase) ||
+             segments[2].Equals("blob", StringComparison.OrdinalIgnoreCase)))
+        {
+            branch = Uri.UnescapeDataString(segments[3]);
+        }
+
+        if (!IsSafeSegment(owner) || !IsSafeSegment(repo) || !IsSafeBranch(branch))
+            return false;
+
+        source = new GscToolSource(owner, repo, branch);
+        return true;
+    }
+
+    private static string TrimDotGit(string repo) =>
+        repo.EndsWith(".git", StringComparison.OrdinalIgnoreCase) ? repo[..^4] : repo;
+
+    private static bool IsSafeSegment(string s) =>
+        !string.IsNullOrWhiteSpace(s) && SegmentRegex().IsMatch(s);
+
+    private static bool IsSafeBranch(string s) =>
+        !string.IsNullOrWhiteSpace(s) && BranchRegex().IsMatch(s);
+
+    [GeneratedRegex(@"^[A-Za-z0-9._-]+$")]
+    private static partial Regex SegmentRegex();
+
+    [GeneratedRegex(@"^[A-Za-z0-9._/\-]+$")]
+    private static partial Regex BranchRegex();
+}

--- a/GSCLSP.Core/Tools/GscToolSource.cs
+++ b/GSCLSP.Core/Tools/GscToolSource.cs
@@ -33,11 +33,9 @@ public sealed record GscToolSource(string Owner, string Repo, string Branch)
         var repo = TrimDotGit(segments[1]);
         var branch = Default.Branch;
 
-        if (segments.Length >= 4 && segments[2].Equals("tree", StringComparison.OrdinalIgnoreCase))
-        {
-            branch = Uri.UnescapeDataString(string.Join("/", segments.Skip(3)));
-        }
-        else if (segments.Length >= 4 && segments[2].Equals("blob", StringComparison.OrdinalIgnoreCase))
+        if (segments.Length >= 4 &&
+            (segments[2].Equals("tree", StringComparison.OrdinalIgnoreCase) ||
+             segments[2].Equals("blob", StringComparison.OrdinalIgnoreCase)))
         {
             branch = Uri.UnescapeDataString(segments[3]);
         }

--- a/GSCLSP.Core/Tools/GscToolSource.cs
+++ b/GSCLSP.Core/Tools/GscToolSource.cs
@@ -1,13 +1,14 @@
-using System.Text.RegularExpressions;
+using static GSCLSP.Core.Models.RegexPatterns;
 
 namespace GSCLSP.Core.Tools;
 
-public sealed partial record GscToolSource(string Owner, string Repo, string Branch)
+public sealed record GscToolSource(string Owner, string Repo, string Branch)
 {
     public static readonly GscToolSource Default = new("xensik", "gsc-tool", "dev");
 
-    public string EngineDirectoryUrl =>
-        $"https://raw.githubusercontent.com/{Owner}/{Repo}/refs/heads/{Branch}/src/gsc/engine/";
+    public Uri EngineDirectoryUri => new(
+        new Uri($"https://raw.githubusercontent.com/{Owner}/{Repo}/"),
+        $"refs/heads/{Branch}/src/gsc/engine/");
 
     public bool IsDefault => Equals(Default);
 
@@ -52,14 +53,8 @@ public sealed partial record GscToolSource(string Owner, string Repo, string Bra
         repo.EndsWith(".git", StringComparison.OrdinalIgnoreCase) ? repo[..^4] : repo;
 
     private static bool IsSafeSegment(string s) =>
-        !string.IsNullOrWhiteSpace(s) && SegmentRegex().IsMatch(s);
+        !string.IsNullOrWhiteSpace(s) && GitHubSegmentRegex().IsMatch(s);
 
     private static bool IsSafeBranch(string s) =>
-        !string.IsNullOrWhiteSpace(s) && BranchRegex().IsMatch(s);
-
-    [GeneratedRegex(@"^[A-Za-z0-9._-]+$")]
-    private static partial Regex SegmentRegex();
-
-    [GeneratedRegex(@"^[A-Za-z0-9._/\-]+$")]
-    private static partial Regex BranchRegex();
+        !string.IsNullOrWhiteSpace(s) && GitHubBranchRegex().IsMatch(s);
 }


### PR DESCRIPTION
this allows the user to change the gsc-tool repository being pointed at for builtins and other data we use. this lets me use my fork of gsc-tool for way more named S4 tokens. 

i added this as a feature for my multi-game GSC project, which let me fix all of my compile errors at runtime just being in the IDE without having to go ingame and have a valid GSC script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for configuring a custom tool repository via gsc_tool_repository in gsclsp.config.json, including robust GitHub URL parsing and branch detection.
  * Repository-scoped built-ins loading so selected sources are displayed by name.

* **Bug Fixes / Improvements**
  * Caching and refresh logic now tied to the chosen repository, preventing stale or mismatched built-ins and improving fetch reliability.
  * Minor logging wording tweaks for cache and JSON load events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lierrmm/GSCLSP/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->