### PR TITLE
feature: GSC dumps/reference per game

### DIFF
--- a/GSCLSP.Core/Indexing/GscIndexer.Workspace.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.Workspace.cs
@@ -124,7 +124,10 @@ public partial class GscIndexer
             {
                 ApplyConfiguredDumpPath();
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"GSCLSP: config reload failed: {ex}");
+            }
         };
 
         _configDebounceTimer.Start();

--- a/GSCLSP.Core/Indexing/GscIndexer.Workspace.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.Workspace.cs
@@ -105,42 +105,8 @@ public partial class GscIndexer
         }
     }
 
-    private static bool IsWorkspaceConfigFile(string fullPath) =>
-        Path.GetFileName(fullPath).Equals("gsclsp.config.json", StringComparison.OrdinalIgnoreCase);
-
-    private void ScheduleConfigReload()
-    {
-        _configDebounceTimer?.Stop();
-        _configDebounceTimer?.Dispose();
-
-        _configDebounceTimer = new System.Timers.Timer(DEBOUNCE_MS)
-        {
-            AutoReset = false,
-        };
-
-        _configDebounceTimer.Elapsed += (_, _) =>
-        {
-            try
-            {
-                ApplyConfiguredDumpPath();
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"GSCLSP: config reload failed: {ex}");
-            }
-        };
-
-        _configDebounceTimer.Start();
-    }
-
     private void OnFileChanged(object sender, FileSystemEventArgs e)
     {
-        if (IsWorkspaceConfigFile(e.FullPath))
-        {
-            ScheduleConfigReload();
-            return;
-        }
-
         if (!IsScriptFile(e.FullPath))
             return;
 
@@ -158,11 +124,6 @@ public partial class GscIndexer
 
     private void OnFileRenamed(object sender, RenamedEventArgs e)
     {
-        if (IsWorkspaceConfigFile(e.OldFullPath) || IsWorkspaceConfigFile(e.FullPath))
-        {
-            ScheduleConfigReload();
-        }
-
         _fileContentCache.Remove(e.OldFullPath);
         OnFileChanged(sender, new FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(e.FullPath)!, Path.GetFileName(e.FullPath)));
     }

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -31,7 +31,6 @@ public partial class GscIndexer
     private readonly HashSet<string> _pendingChanges = [];
     private readonly Lock _pendingChangesLock = new();
     private System.Timers.Timer? _debounceTimer;
-    private System.Timers.Timer? _configDebounceTimer;
     private const int DEBOUNCE_MS = 300;
 
     // Memoization cache for ScanFileForFunction

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -1001,7 +1001,6 @@ public partial class GscIndexer
         if (workspaceConfig?.DumpPaths != null &&
             workspaceConfig.DumpPaths.TryGetValue(CurrentGame, out var perGamePath))
         {
-            Console.Error.WriteLine($"GSCLSP: dumpPaths['{CurrentGame}'] -> {perGamePath}"); //
             return perGamePath;
         }
 

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -19,6 +19,7 @@ public partial class GscIndexer
     public string? DumpPath { get; private set; }
     public string CurrentGame { get; private set; } = "iw4";
     public event Action<string>? GameChanged;
+    public event Action<string, bool>? DumpStatusChanged;
     public List<GscSymbol> WorkspaceSymbols { get; private set; } = [];
     private readonly Dictionary<string, GscFileMap> _workspaceFileMaps = [];
     private readonly Dictionary<string, GscFileMap> _fileMaps = [];
@@ -51,8 +52,6 @@ public partial class GscIndexer
     public record MacroDefinition(string Name, string Value, string FilePath, int Line);
     private static readonly Dictionary<string, List<MacroDefinition>> _macroCache = [];
     private static readonly Lock _macroCacheLock = new();
-
-    private string? _settingDumpPath;
 
     public static string NormalizePath(string? path)
     {
@@ -970,37 +969,49 @@ public partial class GscIndexer
         });
     }
 
-    public void UpdateSettingDumpPath(string? settingDumpPath)
+    public void RefreshConfiguration()
     {
-        _settingDumpPath = settingDumpPath;
         ApplyConfiguredDumpPath();
     }
 
     private void ApplyConfiguredDumpPath()
     {
         var (hasWorkspaceConfig, workspaceConfig) = TryReadWorkspaceConfig(WorkspacePath);
-        var resolvedDumpPath = ResolveDumpPathValue(_settingDumpPath, WorkspacePath, hasWorkspaceConfig, workspaceConfig?.DumpPath);
 
-        if (hasWorkspaceConfig)
+        try
         {
-            if (string.IsNullOrWhiteSpace(workspaceConfig?.DumpPath))
-                Console.Error.WriteLine("GSCLSP: gsclsp.config.json found with no dumpPath. Clearing dump index.");
-            else
-                Console.Error.WriteLine($"GSCLSP: dumpPath from gsclsp.config.json -> {workspaceConfig.DumpPath}");
+            LoadConfiguredBuiltIns(hasWorkspaceConfig, workspaceConfig?.Game, workspaceConfig?.GscToolRepository);
         }
-        else
+        catch (Exception ex)
         {
-            Console.Error.WriteLine("GSCLSP: gsclsp.config.json not found. Dump index disabled unless configured.");
+            Console.Error.WriteLine($"GSCLSP: builtins load failed for game '{CurrentGame}': {ex}");
         }
 
-        LoadConfiguredBuiltIns(hasWorkspaceConfig, workspaceConfig?.Game, workspaceConfig?.GscToolRepository);
+        var rawDumpPath = ResolveRawDumpPath(workspaceConfig);
+        var resolvedDumpPath = NormalizeDumpPath(rawDumpPath, WorkspacePath);
+
+        if (string.Equals(resolvedDumpPath, DumpPath, StringComparison.OrdinalIgnoreCase))
+            return;
+
         UpdateDumpPath(resolvedDumpPath);
+        DumpStatusChanged?.Invoke(CurrentGame, !string.IsNullOrEmpty(resolvedDumpPath) && Directory.Exists(resolvedDumpPath));
     }
 
-    private static string? ResolveDumpPathValue(string? settingDumpPath, string? workspacePath, bool hasWorkspaceConfig, string? workspaceDumpPath)
+    private string? ResolveRawDumpPath(WorkspaceConfig? workspaceConfig)
     {
-        var candidate = hasWorkspaceConfig ? workspaceDumpPath : settingDumpPath;
+        if (workspaceConfig?.DumpPaths != null &&
+            workspaceConfig.DumpPaths.TryGetValue(CurrentGame, out var perGamePath))
+        {
+            Console.Error.WriteLine($"GSCLSP: dumpPaths['{CurrentGame}'] -> {perGamePath}"); //
+            return perGamePath;
+        }
 
+        Console.Error.WriteLine($"GSCLSP: no dump configured for game '{CurrentGame}'.");
+        return null;
+    }
+
+    private static string? NormalizeDumpPath(string? candidate, string? workspacePath)
+    {
         if (string.IsNullOrWhiteSpace(candidate))
             return null;
 
@@ -1140,7 +1151,10 @@ public partial class GscIndexer
         return "iw4";
     }
 
-    private sealed record WorkspaceConfig(string? DumpPath, string? Game, string? GscToolRepository);
+    private sealed record WorkspaceConfig(
+        IReadOnlyDictionary<string, string>? DumpPaths,
+        string? Game,
+        string? GscToolRepository);
 
     private static (bool HasConfigFile, WorkspaceConfig? Config) TryReadWorkspaceConfig(string? workspacePath)
     {
@@ -1167,12 +1181,19 @@ public partial class GscIndexer
             if (root.ValueKind != JsonValueKind.Object)
                 return null;
 
-            string? dumpPath = null;
+            Dictionary<string, string>? dumpPaths = null;
             string? game = null;
             string? gscToolRepository = null;
 
-            if (root.TryGetProperty("dumpPath", out var directDumpPath) && directDumpPath.ValueKind == JsonValueKind.String)
-                dumpPath = directDumpPath.GetString();
+            if (root.TryGetProperty("dumpPaths", out var dumpPathsProperty) && dumpPathsProperty.ValueKind == JsonValueKind.Object)
+            {
+                dumpPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var entry in dumpPathsProperty.EnumerateObject())
+                {
+                    if (entry.Value.ValueKind == JsonValueKind.String && entry.Value.GetString() is { Length: > 0 } path)
+                        dumpPaths[entry.Name] = path;
+                }
+            }
 
             if (root.TryGetProperty("game", out var gameProperty) && gameProperty.ValueKind == JsonValueKind.String)
                 game = gameProperty.GetString();
@@ -1180,7 +1201,7 @@ public partial class GscIndexer
             if (root.TryGetProperty("gsc_tool_repository", out var gscToolRepositoryProperty) && gscToolRepositoryProperty.ValueKind == JsonValueKind.String)
                 gscToolRepository = gscToolRepositoryProperty.GetString();
 
-            return new WorkspaceConfig(dumpPath, game, gscToolRepository);
+            return new WorkspaceConfig(dumpPaths, game, gscToolRepository);
         }
         catch { }
 

--- a/GSCLSP.Core/Models/RegexPatterns.cs
+++ b/GSCLSP.Core/Models/RegexPatterns.cs
@@ -29,9 +29,6 @@ public partial class RegexPatterns
     [GeneratedRegex(@"^#inline\s+([\w\\]+(?:\.\w+)?)")]
     public static partial Regex InlinePathRegex();
 
-    [GeneratedRegex(@"([\w\\]*\\[\w\\]+)::")]
-    public static partial Regex NamespacePathRegex();
-
     [GeneratedRegex(@"//.*")]
     public static partial Regex CommentRegex();
 

--- a/GSCLSP.Extension/README.md
+++ b/GSCLSP.Extension/README.md
@@ -68,7 +68,7 @@ Dump folders are used per game by `dumpPaths` in the config. The current `game` 
 
 ## Choosing Your Target Game
 
-Once you are inside a valid *GSC* file, you will see a `GSC Target Game` dropbox appear in the **bottom right corner.** Choosing the game you are working on will help GSCLSP changes the built-ins list and gives accurate diagnostics.
+Once you are inside a valid *GSC* file, you will see a `GSC Target Game` dropbox appear in the **bottom right corner.** Choosing the game you are working on will help GSCLSP change the built-ins list and gives accurate diagnostics.
 
 If the active game has no entry in `dumpPaths`, no dump is indexed (workspace symbols and engine builtins still work).
 

--- a/GSCLSP.Extension/README.md
+++ b/GSCLSP.Extension/README.md
@@ -2,10 +2,6 @@
 
 [Visual Studio Code](https://code.visualstudio.com/) language support for *Call of Duty®*'s scripting language `.gsc`, `.gsh`, `.csc`, and `.csh` files, powered by the **GSCLSP [C# language server](https://github.com/Lierrmm/GSCLSP/tree/main/GSCLSP.Server)**.
 
-## Choosing Your Target Game
-
-Once you are inside a valid *GSC* file, you will see a `GSC Target Game` dropbox appear in the **bottom right corner.** Choosing the game you are working on will help GSCLSP changes the built-ins list and gives accurate diagnostics.
-
 ## Features
 
 ### Syntax Highlighting
@@ -54,6 +50,28 @@ When you hover your mouse cursor over any sort of function, macro, variable, or 
 ### Code Actions
 - Quick fix to insert `#include ...` for unresolved functions
 
+## Project Setup
+
+When you open a workspace, the extension ensures a `gsclsp.config.json` file exists in the workspace root.
+
+Dump folders are used per game by `dumpPaths` in the config. The current `game` selects which dump is in use. Switching games will swap the dump **automatically.**
+
+```json
+{
+  "game": "s4",
+  "dumpPaths": {
+    "iw5": "D:\\dumps\\iw5",
+    "s4": "D:\\dumps\\s4"
+  }
+}
+```
+
+## Choosing Your Target Game
+
+Once you are inside a valid *GSC* file, you will see a `GSC Target Game` dropbox appear in the **bottom right corner.** Choosing the game you are working on will help GSCLSP changes the built-ins list and gives accurate diagnostics.
+
+If the active game has no entry in `dumpPaths`, no dump is indexed (workspace symbols and engine builtins still work).
+
 ## How to disable warnings/errors
 
 Warnings can be muted on either:
@@ -74,18 +92,6 @@ Aliases supported:
 - `recursive` -> `recursive-function`
 - `semicolon` -> `missing-semicolon`
 - `builtin-args` or `arity` -> `builtin-arg-count`
-
-## Project Setup
-
-When you open a workspace, the extension ensures a `gsclsp.config.json` file exists in the workspace root.
-
-Example:
-
-```json
-{
-  "dumpPath": "D:\\your\\gsc_dump"
-}
-```
 
 ## Command
 

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -150,6 +150,25 @@ function applyDecorationsFor(editor: TextEditor | undefined): void {
   editor.setDecorations(inactiveDecoration, ranges);
 }
 
+interface DumpStatusParams {
+  game: string;
+  hasDump: boolean;
+}
+
+async function handleDumpStatus(params: DumpStatusParams): Promise<void> {
+  if (params.hasDump) return;
+
+  const setUp = "Setup Path";
+  const choice = await window.showWarningMessage(
+    `Could not find a GSC dump for game "${params.game.toUpperCase()}". It is recommended you setup a GSC dump for the best experience.`,
+    setUp,
+  );
+
+  if (choice === setUp) {
+    await commands.executeCommand("gsclsp.browseDumpPath");
+  }
+}
+
 function handleInactiveRegions(params: InactiveRegionsParams): void {
   const uri = Uri.parse(params.uri);
   const key = uri.toString();
@@ -177,6 +196,23 @@ async function ensureWorkspaceConfigFile(folder: WorkspaceFolder): Promise<void>
     await fs.access(configPath);
   } catch {
     await fs.writeFile(configPath, "{}\n", "utf8");
+  }
+
+  const config = await readWorkspaceConfig(folder);
+  let changed = false;
+
+  if ("dumpPath" in config) {
+    delete config.dumpPath;
+    changed = true;
+  }
+
+  if (typeof config.dumpPaths !== "object" || config.dumpPaths === null) {
+    config.dumpPaths = {};
+    changed = true;
+  }
+
+  if (changed) {
+    await writeWorkspaceConfig(folder, config);
   }
 }
 
@@ -231,19 +267,21 @@ export async function activate(context: ExtensionContext): Promise<void> {
             );
 
             try {
-              let config: { dumpPath?: string } = {};
+              let config: { dumpPaths?: Record<string, string> } = {};
 
               try {
                 const existing = await fs.readFile(configPath, "utf8");
                 const parsed = JSON.parse(existing) as unknown;
                 if (parsed && typeof parsed === "object") {
-                  config = parsed as { dumpPath?: string };
+                  config = parsed as typeof config;
                 }
               } catch {
                 config = {};
               }
 
-              config.dumpPath = newPath;
+              const game = (await readTargetGame()) ?? "iw4";
+              config.dumpPaths = { ...(config.dumpPaths ?? {}), [game]: newPath };
+
               await fs.writeFile(
                 configPath,
                 JSON.stringify(config, null, 2),
@@ -251,7 +289,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
               );
 
               window.showInformationMessage(
-                `GSCLSP: Updated ${configPath}`,
+                `GSCLSP: Set dump folder for ${game.toUpperCase()}`,
               );
             } catch (error) {
               const message =
@@ -334,9 +372,14 @@ export async function activate(context: ExtensionContext): Promise<void> {
     commands.registerCommand("gsclsp.selectTargetGame", selectTargetGameCommand),
   );
 
+  const onConfigChanged = async (): Promise<void> => {
+    await updateStatusBar();
+    await client.sendNotification("custom/reloadConfig", {});
+  };
+
   const configWatcher = workspace.createFileSystemWatcher("**/gsclsp.config.json");
-  configWatcher.onDidChange(() => updateStatusBar());
-  configWatcher.onDidCreate(() => updateStatusBar());
+  configWatcher.onDidChange(onConfigChanged);
+  configWatcher.onDidCreate(onConfigChanged);
   configWatcher.onDidDelete(() => updateStatusBar());
   context.subscriptions.push(configWatcher);
 
@@ -348,6 +391,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   context.subscriptions.push(
     client.onNotification("custom/inactiveRegions", handleInactiveRegions),
+  );
+
+  context.subscriptions.push(
+    client.onNotification("custom/dumpStatus", handleDumpStatus),
   );
 
   context.subscriptions.push(

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -201,13 +201,19 @@ async function ensureWorkspaceConfigFile(folder: WorkspaceFolder): Promise<void>
   const config = await readWorkspaceConfig(folder);
   let changed = false;
 
-  if ("dumpPath" in config) {
-    delete config.dumpPath;
+  if (typeof config.dumpPaths !== "object" || config.dumpPaths === null) {
+    config.dumpPaths = {};
     changed = true;
   }
 
-  if (typeof config.dumpPaths !== "object" || config.dumpPaths === null) {
-    config.dumpPaths = {};
+  if ("dumpPath" in config) {
+    const legacy = config.dumpPath;
+    const game = (await readTargetGame()) ?? "iw4";
+    const paths = config.dumpPaths as Record<string, unknown>;
+    if (typeof legacy === "string" && legacy.length > 0 && !(game in paths)) {
+      paths[game] = legacy;
+    }
+    delete config.dumpPath;
     changed = true;
   }
 
@@ -355,7 +361,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
   );
 
   context.subscriptions.push(client);
-  await client.start();
 
   if (context.extensionMode === ExtensionMode.Development) {
     await client.setTrace(Trace.Verbose);
@@ -409,6 +414,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
       for (const e of editors) applyDecorationsFor(e);
     }),
   );
+
+  await client.start();
 }
 
 export async function deactivate(): Promise<void> {

--- a/GSCLSP.Server/Handlers/GscCompletionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionHandler.cs
@@ -370,6 +370,7 @@ namespace GSCLSP.Server.Handlers
                 addedFolder = true;
             }
 
+            // the return value only decides whether to stop the parent function early
             return lastSlash >= 0 && addedFolder;
 
             string ToRelativeScriptPath(string filePath)

--- a/GSCLSP.Server/Handlers/GscCompletionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionHandler.cs
@@ -9,11 +9,19 @@ using static GSCLSP.Core.Models.RegexPatterns;
 
 namespace GSCLSP.Server.Handlers
 {
-    public partial class GscCompletionHandler(GscIndexer indexer, GscDocumentStore documentStore) : ICompletionHandler
+    public partial class GscCompletionHandler : ICompletionHandler
     {
-        private readonly GscIndexer _indexer = indexer;
-        private readonly GscDocumentStore _documentStore = documentStore;
+        private readonly GscIndexer _indexer;
+        private readonly GscDocumentStore _documentStore;
         private readonly ConcurrentDictionary<string, HashSet<string>> _fileIncludesCache = [];
+
+        public GscCompletionHandler(GscIndexer indexer, GscDocumentStore documentStore)
+        {
+            _indexer = indexer;
+            _documentStore = documentStore;
+
+            _indexer.DumpStatusChanged += (_, _) => _fileIncludesCache.Clear();
+        }
 
         public async Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
         {
@@ -154,6 +162,7 @@ namespace GSCLSP.Server.Handlers
                                 LabelDetails = new CompletionItemLabelDetails { Description = "(folder)" },
                                 Kind = CompletionItemKind.Folder,
                                 FilterText = folder,
+                                SortText = "0_" + folder,
                                 InsertTextFormat = InsertTextFormat.PlainText,
                                 TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit { Range = segmentRange, NewText = folder + "\\" }),
                                 Command = new Command { Name = "editor.action.triggerSuggest" }
@@ -169,6 +178,7 @@ namespace GSCLSP.Server.Handlers
                             LabelDetails = new CompletionItemLabelDetails { Description = isGsh ? ".gsh" : ".gsc" },
                             Kind = CompletionItemKind.File,
                             FilterText = fileName,
+                            SortText = "1_" + fileName,
                             InsertTextFormat = InsertTextFormat.PlainText,
                             TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit { Range = segmentRange, NewText = fileName })
                         });
@@ -178,6 +188,13 @@ namespace GSCLSP.Server.Handlers
                 return GscCompletionItemFactory.ToFilteredList(completions);
             }
 
+            // namespaces from the dump are shown as a high priority
+            if (AddNamespaceFolderCompletions(completions, lineUntilCursor, request.Position))
+            {
+                return GscCompletionItemFactory.ToFilteredList(completions);
+            }
+
+            // using :: after the namespace is defined for functions only
             var namespaceMatch = NameSpaceRegex().Match(lineUntilCursor);
             if (namespaceMatch.Success)
             {
@@ -299,6 +316,87 @@ namespace GSCLSP.Server.Handlers
             foreach (var define in GscCompletionItemFactory.BuiltInDefines)
                 completions.Add(define);
         }
+
+        private bool AddNamespaceFolderCompletions(List<CompletionItem> completions, string lineUntilCursor, Position position)
+        {
+            if (lineUntilCursor.Contains("::", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var pathStart = lineUntilCursor.Length;
+            while (pathStart > 0 && IsPathChar(lineUntilCursor[pathStart - 1]))
+            {
+                pathStart--;
+            }
+
+            if (pathStart == lineUntilCursor.Length)
+            {
+                return false;
+            }
+
+            var typedPath = lineUntilCursor[pathStart..].Replace("/", "\\");
+            var lastSlash = typedPath.LastIndexOf('\\');
+            var prefix = lastSlash >= 0 ? typedPath[..(lastSlash + 1)] : string.Empty;
+            var segmentStart = lastSlash >= 0 ? pathStart + lastSlash + 1 : pathStart;
+            var segmentRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                new Position(position.Line, segmentStart),
+                position);
+
+            var folders = _indexer.GetAllIndexedFilePaths()
+                .Select(ToRelativeScriptPath)
+                .Where(p => p.EndsWith(".gsc", StringComparison.OrdinalIgnoreCase))
+                .Select(p => p.Replace("/", "\\"))
+                .Where(p => p.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                .Select(p => p[prefix.Length..])
+                .Where(p => p.Contains('\\'))
+                .Select(p => p[..p.IndexOf('\\')])
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+
+            var addedFolder = false;
+            foreach (var folder in folders)
+            {
+                completions.Add(new CompletionItem
+                {
+                    Label = folder,
+                    LabelDetails = new CompletionItemLabelDetails { Description = "(folder)" },
+                    Kind = CompletionItemKind.Folder,
+                    FilterText = folder,
+                    SortText = "0_" + folder,
+                    InsertTextFormat = InsertTextFormat.PlainText,
+                    TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit { Range = segmentRange, NewText = folder + "\\" }),
+                    Command = new Command { Name = "editor.action.triggerSuggest" }
+                });
+                addedFolder = true;
+            }
+
+            return lastSlash >= 0 && addedFolder;
+
+            string ToRelativeScriptPath(string filePath)
+            {
+                var normalized = filePath.Replace("\\", "/");
+                foreach (var rootPath in new[] { _indexer.WorkspacePath, _indexer.DumpPath })
+                {
+                    if (rootPath == null)
+                    {
+                        continue;
+                    }
+
+                    var root = rootPath.Replace("\\", "/").TrimEnd('/');
+                    if (!normalized.StartsWith(root + "/", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    return normalized[(root.Length + 1)..];
+                }
+
+                return normalized;
+            }
+        }
+
+        private static bool IsPathChar(char c) =>
+            char.IsLetterOrDigit(c) || c == '_' || c == '\\' || c == '/';
 
         private static bool IsPreprocessorOperand(string trimmedLine)
         {

--- a/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
@@ -31,13 +31,23 @@ public class GscDiagnosticsHandler
         _diagnosticsAnalyzer = new GscDiagnosticsAnalyzer(indexer);
 
         _indexer.GameChanged += _ => StartRepublishAllOpenDocuments();
+        _indexer.DumpStatusChanged += (game, hasDump) =>
+            _languageServer.SendNotification("custom/dumpStatus", new { game, hasDump });
     }
 
     private void StartRepublishAllOpenDocuments()
     {
         var cancellationTokenSource = new CancellationTokenSource();
         var previous = Interlocked.Exchange(ref _republishCancellationTokenSource, cancellationTokenSource);
-        previous?.Cancel();
+
+        // this is kinda meme, but just silenty error. we dont really care here
+        try
+        {
+            previous?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
 
         _ = RepublishAllOpenDocumentsAsync(cancellationTokenSource);
     }

--- a/GSCLSP.Server/Program.cs
+++ b/GSCLSP.Server/Program.cs
@@ -35,6 +35,7 @@ var server = await LanguageServer.From(options =>
         .WithHandler<GscReferencesHandler>()
         .WithHandler<GscCodeActionHandler>()
         .WithHandler<GscRenameHandler>()
+        .OnNotification("custom/reloadConfig", () => indexer.RefreshConfiguration())
         .OnInitialize((server, request, token) =>
         {
             var workspacePath = request.RootPath
@@ -47,7 +48,7 @@ var server = await LanguageServer.From(options =>
             }
             else
             {
-                indexer.UpdateSettingDumpPath(null);
+                indexer.RefreshConfiguration();
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
closes #35 and adds GSC dumps per games

this deletes the legacy `dumpPath` inside configs and simply creates a null `dumpPaths` object. instead, the UI will now prompt a warning when no dump is use with a quick button to set up that dump. this should be way more user friendly and let people take advantage of these cool features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-game dump path configuration (select different dump for each target game)
  * Dump status notifications with prompts to set missing dumps and game-specific success messages
  * Improved code completion with folder-level suggestions for includes/inline

* **Bug Fixes**
  * Configuration changes now refresh the status bar and trigger a client reload on create/change

* **Documentation**
  * Project Setup updated to document per-game dumpPaths and target-game behaviour
<!-- end of auto-generated comment: release notes by coderabbit.ai -->