### PR TITLE
properly support `function` keyword for GSCOBJ gsc

### DIFF
--- a/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
+++ b/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
@@ -257,6 +257,10 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer)
             if (line.TrimEnd().EndsWith(';'))
                 continue;
 
+            var trimmed = line.TrimStart();
+            if (!IsPotentialFuncDefLine(trimmed))
+                continue;
+
             var match = FunctionMultiLineRegex().Match(line);
             if (!match.Success)
                 continue;
@@ -682,7 +686,7 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer)
         var codeLine = StripTrailingLineComment(line);
 
         if (codeLine.Length == 0 || char.IsWhiteSpace(codeLine[0])) return false;
-        if (matchIndex != 0) return false;
+        if (matchIndex != 0 && !GscLanguageKeywords.IsValidFunctionPrefix(codeLine.AsSpan(0, matchIndex))) return false;
         if (codeLine.Contains(';')) return false;
 
         var match = FunctionMultiLineRegex().Match(codeLine);
@@ -690,6 +694,21 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer)
             return false;
 
         return codeLine.Contains('{') || (lineIndex + 1 < lines.Length && StripTrailingLineComment(lines[lineIndex + 1]).TrimStart().StartsWith('{'));
+    }
+
+    private static bool IsPotentialFuncDefLine(string trimmed)
+    {
+        if (trimmed.StartsWith("function", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        int i = 0;
+        while (i < trimmed.Length && !char.IsWhiteSpace(trimmed[i]) && trimmed[i] != '(') i++;
+        if (i == 0)
+            return false;
+
+        var firstWord = trimmed.AsSpan(0, i);
+        return GscLanguageKeywords.FunctionModifierKeywords.Contains(firstWord.ToString()) ||
+                System.Text.RegularExpressions.Regex.IsMatch(firstWord.ToString(), @"^[a-zA-Z_]\w*$");
     }
 
     private static string StripTrailingLineComment(string line)

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -214,7 +214,10 @@ public partial class GscIndexer
             return false;
 
         var match = FunctionMultiLineRegex().Match(codeLine);
-        if (!match.Success || match.Index != 0)
+        if (!match.Success)
+            return false;
+
+        if (match.Index != 0 && !GscLanguageKeywords.IsValidFunctionPrefix(codeLine.AsSpan(0, match.Index)))
             return false;
 
         var name = match.Groups["name"].Value;
@@ -438,22 +441,62 @@ public partial class GscIndexer
                 if (codeLine.Contains(';'))
                     continue;
 
-                // Quick reject: line must start with function name (case-insensitive)
+                // Quick reject: line must start with function name or valid modifier keywords
                 if (fnLen == 0 || codeLine.Length < fnLen)
                     continue;
 
+                int pos = -1;
+                string checkLine = codeLine;
+
                 if (!codeLine.StartsWith(fnName, StringComparison.OrdinalIgnoreCase))
-                    continue;
+                {
+                    bool skipLine = false;
+                    foreach (var mod in GscLanguageKeywords.FunctionModifierKeywords)
+                    {
+                        if (checkLine.StartsWith(mod, StringComparison.OrdinalIgnoreCase))
+                        {
+                            int afterMod = mod.Length;
+                            while (afterMod < checkLine.Length && char.IsWhiteSpace(checkLine[afterMod])) afterMod++;
+                            if (afterMod >= checkLine.Length)
+                            {
+                                skipLine = true;
+                                break;
+                            }
+                            checkLine = checkLine.Substring(afterMod);
+                        }
+                    }
 
-                // Next character after name should be whitespace or '('
-                if (codeLine.Length == fnLen)
-                    continue;
+                    if (!skipLine && !checkLine.StartsWith(fnName, StringComparison.OrdinalIgnoreCase))
+                        skipLine = true;
 
-                int pos = fnLen;
-                // skip whitespace
-                while (pos < codeLine.Length && char.IsWhiteSpace(codeLine[pos])) pos++;
-                if (pos >= codeLine.Length || codeLine[pos] != '(')
-                    continue;
+                    if (!skipLine)
+                    {
+                        int nameStartInCodeLine = codeLine.Length - checkLine.Length;
+                        int nameEnd = nameStartInCodeLine + fnLen;
+                        if (nameEnd >= codeLine.Length)
+                            skipLine = true;
+                        else
+                        {
+                            pos = nameEnd;
+                            while (pos < codeLine.Length && char.IsWhiteSpace(codeLine[pos])) pos++;
+                            if (pos >= codeLine.Length || codeLine[pos] != '(')
+                                skipLine = true;
+                        }
+                    }
+
+                    if (skipLine)
+                        continue;
+                }
+                else
+                {
+                    if (codeLine.Length == fnLen)
+                        continue;
+
+                    pos = fnLen;
+                    while (pos < codeLine.Length && char.IsWhiteSpace(codeLine[pos])) pos++;
+                    if (pos >= codeLine.Length || codeLine[pos] != '(')
+                        continue;
+                }
 
                 // Find closing ')' on the same line
                 int closeParen = codeLine.IndexOf(')', pos + 1);

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -451,19 +451,31 @@ public partial class GscIndexer
                 if (!codeLine.StartsWith(fnName, StringComparison.OrdinalIgnoreCase))
                 {
                     bool skipLine = false;
-                    foreach (var mod in GscLanguageKeywords.FunctionModifierKeywords)
+                    while (true)
                     {
-                        if (checkLine.StartsWith(mod, StringComparison.OrdinalIgnoreCase))
+                        bool matchedModifier = false;
+                        foreach (var mod in GscLanguageKeywords.FunctionModifierKeywords)
                         {
-                            int afterMod = mod.Length;
-                            while (afterMod < checkLine.Length && char.IsWhiteSpace(checkLine[afterMod])) afterMod++;
-                            if (afterMod >= checkLine.Length)
+                            if (checkLine.StartsWith(mod, StringComparison.OrdinalIgnoreCase))
                             {
-                                skipLine = true;
+                                int afterMod = mod.Length;
+                                if (afterMod < checkLine.Length && (char.IsLetterOrDigit(checkLine[afterMod]) || checkLine[afterMod] == '_'))
+                                    continue;
+
+                                while (afterMod < checkLine.Length && char.IsWhiteSpace(checkLine[afterMod])) afterMod++;
+                                if (afterMod >= checkLine.Length)
+                                {
+                                    skipLine = true;
+                                    break;
+                                }
+                                checkLine = checkLine.Substring(afterMod);
+                                matchedModifier = true;
                                 break;
                             }
-                            checkLine = checkLine.Substring(afterMod);
                         }
+
+                        if (skipLine || !matchedModifier)
+                            break;
                     }
 
                     if (!skipLine && !checkLine.StartsWith(fnName, StringComparison.OrdinalIgnoreCase))

--- a/GSCLSP.Core/Models/GscLanguageKeywords.cs
+++ b/GSCLSP.Core/Models/GscLanguageKeywords.cs
@@ -13,8 +13,40 @@ public static class GscLanguageKeywords
         "assert", "assertex", "assertmsg",
         "true", "false", "undefined",
         "size", "game", "self", "anim", "level",
-        "isdefined", "istrue"
+        "isdefined", "istrue",
+        "function", "private", "autoexec"
     };
+
+    public static readonly HashSet<string> FunctionModifierKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "function", "private", "autoexec"
+    };
+
+    /// <summary>
+    /// Validates that a prefix consists only of allowed function modifier keywords (function, private, autoexec).
+    /// </summary>
+    public static bool IsValidFunctionPrefix(ReadOnlySpan<char> prefix)
+    {
+        if (prefix.IsEmpty)
+            return true;
+
+        int i = 0;
+        while (i < prefix.Length)
+        {
+            while (i < prefix.Length && char.IsWhiteSpace(prefix[i])) i++;
+            if (i >= prefix.Length)
+                return true;
+
+            int start = i;
+            while (i < prefix.Length && !char.IsWhiteSpace(prefix[i])) i++;
+
+            var word = prefix[start..i];
+            if (!FunctionModifierKeywords.Contains(word.ToString()))
+                return false;
+        }
+
+        return true;
+    }
 
     public static readonly HashSet<string> LocalVariableReservedWords = new(StringComparer.OrdinalIgnoreCase)
     {

--- a/GSCLSP.Core/Models/RegexPatterns.cs
+++ b/GSCLSP.Core/Models/RegexPatterns.cs
@@ -17,7 +17,7 @@ public partial class RegexPatterns
     [GeneratedRegex(@"([\w\\]+)::$")]
     public static partial Regex NameSpaceRegex();
 
-    [GeneratedRegex(@"^(?<name>[a-zA-Z_]\w*)\s*\((?<params>[^)]*)\)", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^(?:(?:function\s+(?:private\s+)?(?:autoexec\s+)?)\s*)?(?<name>[a-zA-Z_]\w*)\s*\((?<params>[^)]*)\)", RegexOptions.Multiline)]
     public static partial Regex FunctionMultiLineRegex();
 
     [GeneratedRegex(@"(Summary|Example|MandatoryArg|OptionalArg|Module|CallOn|SPMP):")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of function definitions, including cases with supported prefixes before the function name.
  * Reduced false positives by ignoring lines that do not look like valid function definitions.
  * Made function scanning more accurate when functions use common modifiers such as `private` or `autoexec`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->