### PR TITLE
add `level` keyword indexing

### DIFF
--- a/GSCLSP.Core/Indexing/GscIndexer.LevelFields.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.LevelFields.cs
@@ -1,0 +1,157 @@
+using GSCLSP.Core.Models;
+using GSCLSP.Core.Services;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using static GSCLSP.Core.Models.RegexPatterns;
+
+namespace GSCLSP.Core.Indexing;
+
+public partial class GscIndexer
+{
+    // level fields from the dump, deduplicated by name; persisted to levelfields.json
+    private readonly Dictionary<string, GscLevelField> _dumpLevelFields = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Lock _levelFieldsLock = new();
+
+    public static List<GscLevelField> ScanLevelFields(string[] lines, string filePath)
+    {
+        var result = new List<GscLevelField>();
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var codeLine = StripTrailingLineComment(lines[i]);
+            if (codeLine.Length == 0) continue;
+
+            foreach (System.Text.RegularExpressions.Match match in LevelFieldAssignmentRegex().Matches(codeLine))
+            {
+                var name = match.Groups["name"].Value;
+                var isDirectAssignment = match.Groups["access"].Length == 0 && match.Groups["op"].Value == "=";
+                var value = isDirectAssignment ? match.Groups["value"].Value.Trim() : string.Empty;
+
+                result.Add(new GscLevelField(name, filePath, i + 1, value));
+            }
+        }
+
+        return result;
+    }
+
+    private void AddDumpLevelField(GscLevelField field)
+    {
+        lock (_levelFieldsLock)
+        {
+            // prefer a definition that shows a direct `level.x = value` assignment
+            if (_dumpLevelFields.TryGetValue(field.Name, out var existing) &&
+                (existing.Value.Length > 0 || field.Value.Length == 0))
+                return;
+
+            _dumpLevelFields[field.Name] = field;
+        }
+    }
+
+    private void ClearDumpLevelFields()
+    {
+        lock (_levelFieldsLock)
+        {
+            _dumpLevelFields.Clear();
+        }
+    }
+
+    private void IndexLevelFieldsFolder(string folderPath)
+    {
+        if (!Directory.Exists(folderPath)) return;
+
+        var files = Directory.GetFiles(folderPath, "*.*", SearchOption.AllDirectories)
+            .Where(IsScriptFile);
+
+        foreach (var file in files)
+        {
+            try
+            {
+                foreach (var field in ScanLevelFields(File.ReadAllLines(file), file))
+                    AddDumpLevelField(field);
+            }
+            catch (IOException) { }
+        }
+    }
+
+    private void SaveLevelFieldsCache(string outputPath)
+    {
+        try
+        {
+            List<GscLevelField> snapshot;
+            lock (_levelFieldsLock)
+            {
+                snapshot = [.. _dumpLevelFields.Values];
+            }
+
+            File.WriteAllText(outputPath, JsonSerializer.Serialize(snapshot, GscJsonContext.Default.ListGscLevelField));
+            _logger.LogDebug("Saved {Count} level fields to {Path}.", snapshot.Count, outputPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write level fields cache {Path}", outputPath);
+        }
+    }
+
+    private void LoadLevelFieldsCache(string jsonPath)
+    {
+        try
+        {
+            var fields = JsonSerializer.Deserialize(File.ReadAllText(jsonPath), GscJsonContext.Default.ListGscLevelField);
+            if (fields == null) return;
+
+            foreach (var field in fields)
+                AddDumpLevelField(field);
+
+            _logger.LogDebug("Indexer loaded {Count} level fields from JSON.", fields.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read level fields cache {Path}", jsonPath);
+        }
+    }
+
+    public GscLevelField? ResolveLevelField(string name)
+    {
+        GscLevelField? fallback = null;
+
+        foreach (var map in _workspaceFileMaps.Values)
+        {
+            foreach (var field in map.LevelFields)
+            {
+                if (!field.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) continue;
+                if (field.Value.Length > 0) return field;
+                fallback ??= field;
+            }
+        }
+
+        if (fallback != null) return fallback;
+
+        lock (_levelFieldsLock)
+        {
+            return _dumpLevelFields.TryGetValue(name, out var dumpField) ? dumpField : null;
+        }
+    }
+
+    public List<GscLevelField> GetAllLevelFields()
+    {
+        var seen = new Dictionary<string, GscLevelField>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var map in _workspaceFileMaps.Values)
+        {
+            foreach (var field in map.LevelFields)
+            {
+                if (!seen.TryGetValue(field.Name, out var existing) ||
+                    (existing.Value.Length == 0 && field.Value.Length > 0))
+                    seen[field.Name] = field;
+            }
+        }
+
+        lock (_levelFieldsLock)
+        {
+            foreach (var field in _dumpLevelFields.Values)
+                seen.TryAdd(field.Name, field);
+        }
+
+        return [.. seen.Values];
+    }
+}

--- a/GSCLSP.Core/Indexing/GscIndexer.LevelFields.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.LevelFields.cs
@@ -70,6 +70,8 @@ public partial class GscIndexer
                     AddDumpLevelField(field);
             }
             catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+            catch (System.Security.SecurityException) { }
         }
     }
 

--- a/GSCLSP.Core/Indexing/GscIndexer.Workspace.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.Workspace.cs
@@ -217,6 +217,7 @@ public partial class GscIndexer
         _symbols.Clear();
         _fileMaps.Clear();
         _fileNamespaceCache.Clear();
+        ClearDumpLevelFields();
 
         lock (_scanCacheLock)
         {
@@ -298,6 +299,7 @@ public partial class GscIndexer
         var lines = File.ReadAllLines(filePath);
 
         fileMap.OverridePath = ExtractOverridePath(lines);
+        fileMap.LevelFields = ScanLevelFields(lines, filePath);
 
         for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++)
         {

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -91,6 +91,7 @@ public partial class GscIndexer(ILogger logger)
     public TimeSpan IndexFolder(string folderPath)
     {
         _symbols.Clear();
+        ClearDumpLevelFields();
         var sw = Stopwatch.StartNew();
 
         if (Directory.Exists(folderPath))
@@ -122,18 +123,32 @@ public partial class GscIndexer(ILogger logger)
         DumpPath = newPath;
         ClearGlobalIndexAndCaches();
 
+        string levelFieldsCacheFile = Path.Combine(newPath, "levelfields.json");
+
         Task _ = Task.Run(() =>
         {
             if (File.Exists(cacheFile))
             {
                 _logger.LogDebug("Loading existing GSC dump cache from {CacheFile}", cacheFile);
                 LoadGlobalIndex(cacheFile);
+
+                if (File.Exists(levelFieldsCacheFile))
+                {
+                    LoadLevelFieldsCache(levelFieldsCacheFile);
+                }
+                else
+                {
+                    _logger.LogDebug("No level fields cache found. Crawling folder {FolderPath}...", newPath);
+                    IndexLevelFieldsFolder(newPath);
+                    SaveLevelFieldsCache(levelFieldsCacheFile);
+                }
             }
             else
             {
                 _logger.LogDebug("No cache found. Crawling folder {FolderPath}...", newPath);
                 IndexFolder(newPath);
                 ExportIndexToJson(newPath, cacheFile);
+                SaveLevelFieldsCache(levelFieldsCacheFile);
 
                 _logger.LogDebug("Created new cache with {Count} symbols.", _symbols.Count);
                 LoadGlobalIndex(cacheFile);
@@ -168,6 +183,9 @@ public partial class GscIndexer(ILogger logger)
     {
         var fileMap = new GscFileMap { FilePath = path };
         var lines = File.ReadAllLines(path);
+
+        foreach (var levelField in ScanLevelFields(lines, path))
+            AddDumpLevelField(levelField);
 
         for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++)
         {

--- a/GSCLSP.Core/Models/GscFileMap.cs
+++ b/GSCLSP.Core/Models/GscFileMap.cs
@@ -9,4 +9,5 @@ public class GscFileMap
     public List<string> Usings { get; set; } = [];
     public List<string> Inlines { get; set; } = [];
     public List<GscSymbol> LocalSymbols { get; set; } = [];
+    public List<GscLevelField> LevelFields { get; set; } = [];
 }

--- a/GSCLSP.Core/Models/GscLevelField.cs
+++ b/GSCLSP.Core/Models/GscLevelField.cs
@@ -1,0 +1,8 @@
+namespace GSCLSP.Core.Models;
+
+public record GscLevelField(
+    string Name,
+    string FilePath,
+    int LineNumber,
+    string Value
+);

--- a/GSCLSP.Core/Models/RegexPatterns.cs
+++ b/GSCLSP.Core/Models/RegexPatterns.cs
@@ -79,4 +79,10 @@ public partial class RegexPatterns
 
     [GeneratedRegex(@"^\s*")]
     public static partial Regex LeadingWhitespaceRegex();
+
+    [GeneratedRegex(@"(?<![.\w\\])level\s*\.\s*(?<name>[A-Za-z_]\w*)(?<access>(?:\s*\.\s*\w+|\s*\[[^\]\r\n]*\])*)\s*(?<op>\+\+|--|[-+*/%&|^]?=(?!=))\s*(?<value>[^;\r\n]*)", RegexOptions.IgnoreCase)]
+    public static partial Regex LevelFieldAssignmentRegex();
+
+    [GeneratedRegex(@"(?<![.\w\\])level\s*\.\s*(?<partial>[A-Za-z_]\w*)?$", RegexOptions.IgnoreCase)]
+    public static partial Regex LevelFieldAccessRegex();
 }

--- a/GSCLSP.Core/Services/GscJsonContext.cs
+++ b/GSCLSP.Core/Services/GscJsonContext.cs
@@ -6,6 +6,8 @@ using System.Text.Json.Serialization;
 [JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(List<GscSymbol>))]
 [JsonSerializable(typeof(GscSymbol))]
+[JsonSerializable(typeof(List<GscLevelField>))]
+[JsonSerializable(typeof(GscLevelField))]
 internal partial class GscJsonContext : JsonSerializerContext
 {
 }

--- a/GSCLSP.Server/Handlers/GscCompletionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionHandler.cs
@@ -184,6 +184,25 @@ namespace GSCLSP.Server.Handlers
                 return GscCompletionItemFactory.ToFilteredList(completions);
             }
 
+            if (LevelFieldAccessRegex().IsMatch(lineUntilCursor))
+            {
+                var seenFields = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var field in GscIndexer.ScanLevelFields(currentFileLines, currentFilePath))
+                {
+                    if (seenFields.Add(field.Name))
+                        completions.Add(GscCompletionItemFactory.FromLevelField(field));
+                }
+
+                foreach (var field in _indexer.GetAllLevelFields())
+                {
+                    if (seenFields.Add(field.Name))
+                        completions.Add(GscCompletionItemFactory.FromLevelField(field));
+                }
+
+                return GscCompletionItemFactory.ToFilteredList(completions);
+            }
+
             var isTreyarch = _indexer.IsTreyarchGsc;
 
             if (!isTreyarch)

--- a/GSCLSP.Server/Handlers/GscCompletionItemFactory.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionItemFactory.cs
@@ -184,6 +184,28 @@ internal static class GscCompletionItemFactory
         };
     }
 
+    public static CompletionItem FromLevelField(GscLevelField field)
+    {
+        return new CompletionItem
+        {
+            Label = field.Name,
+            LabelDetails = new CompletionItemLabelDetails
+            {
+                Detail = field.Value.Length > 0 ? $" = {field.Value}" : "",
+                Description = "Level Field"
+            },
+            Kind = CompletionItemKind.Field,
+            Documentation = new StringOrMarkupContent(new MarkupContent
+            {
+                Kind = MarkupKind.Markdown,
+                Value = $"**Source:** `{Path.GetFileName(field.FilePath)}`"
+            }),
+            InsertText = field.Name,
+            InsertTextFormat = InsertTextFormat.PlainText,
+            FilterText = field.Name
+        };
+    }
+
     public static CompletionItem FromLocalVariable(GscIndexer.LocalVariable localVar)
     {
         return new CompletionItem

--- a/GSCLSP.Server/Handlers/GscDefinitionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDefinitionHandler.cs
@@ -72,14 +72,7 @@ public class GscDefinitionHandler(GscIndexer indexer, GscDocumentStore documentS
 
         if (GscHandlerCommon.TryGetLevelFieldAt(line, request.Position.Character, out var levelFieldName))
         {
-            var docMatches = GscIndexer.ScanLevelFields(lines, currentFilePath)
-                .Where(f => f.Name.Equals(levelFieldName, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
-            var field = docMatches.FirstOrDefault(f => f.Value.Length > 0)
-                ?? docMatches.FirstOrDefault()
-                ?? _indexer.ResolveLevelField(levelFieldName);
-
+            var field = GscHandlerCommon.ResolveLevelField(_indexer, lines, currentFilePath, levelFieldName);
             if (field == null) return new DefinitionResult();
 
             int fieldLine = field.LineNumber - 1;

--- a/GSCLSP.Server/Handlers/GscDefinitionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDefinitionHandler.cs
@@ -70,6 +70,29 @@ public class GscDefinitionHandler(GscIndexer indexer, GscDocumentStore documentS
             });
         }
 
+        if (GscHandlerCommon.TryGetLevelFieldAt(line, request.Position.Character, out var levelFieldName))
+        {
+            var docMatches = GscIndexer.ScanLevelFields(lines, currentFilePath)
+                .Where(f => f.Name.Equals(levelFieldName, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var field = docMatches.FirstOrDefault(f => f.Value.Length > 0)
+                ?? docMatches.FirstOrDefault()
+                ?? _indexer.ResolveLevelField(levelFieldName);
+
+            if (field == null) return new DefinitionResult();
+
+            int fieldLine = field.LineNumber - 1;
+            return new DefinitionResult(new Location
+            {
+                Uri = DocumentUri.FromFileSystemPath(field.FilePath),
+                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                    new Position(fieldLine, 0),
+                    new Position(fieldLine, 0)
+                )
+            });
+        }
+
         var globalVar = GscIndexer.ResolveGlobalVariable(currentFilePath, identifier);
         if (globalVar != null)
         {

--- a/GSCLSP.Server/Handlers/GscHandlerCommon.cs
+++ b/GSCLSP.Server/Handlers/GscHandlerCommon.cs
@@ -40,6 +40,49 @@ internal static class GscHandlerCommon
         return false;
     }
 
+    public static bool TryGetLevelFieldAt(string line, int character, out string fieldName)
+    {
+        fieldName = string.Empty;
+
+        static bool IsWordChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+        int start = Math.Clamp(character, 0, line.Length);
+        if (start >= line.Length || !IsWordChar(line[start]))
+        {
+            if (start > 0 && IsWordChar(line[start - 1])) start--;
+            else return false;
+        }
+
+        while (start > 0 && IsWordChar(line[start - 1])) start--;
+
+        int end = start;
+        while (end < line.Length && IsWordChar(line[end])) end++;
+
+        if (end == start || char.IsDigit(line[start])) return false;
+
+        int i = start - 1;
+        while (i >= 0 && char.IsWhiteSpace(line[i])) i--;
+        if (i < 0 || line[i] != '.') return false;
+
+        i--;
+        while (i >= 0 && char.IsWhiteSpace(line[i])) i--;
+        if (i < 0) return false;
+
+        int callerEnd = i + 1;
+        int callerStart = callerEnd;
+        while (callerStart > 0 && IsWordChar(line[callerStart - 1])) callerStart--;
+
+        if (!line[callerStart..callerEnd].Equals("level", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        // reject chained access like foo.level.x or maps\level.x
+        if (callerStart > 0 && (line[callerStart - 1] == '.' || line[callerStart - 1] == '\\'))
+            return false;
+
+        fieldName = line[start..end];
+        return true;
+    }
+
     public static List<(int Start, int End)> GetCodeRanges(string line, ref bool inBlockComment)
     {
         var ranges = new List<(int Start, int End)>();

--- a/GSCLSP.Server/Handlers/GscHandlerCommon.cs
+++ b/GSCLSP.Server/Handlers/GscHandlerCommon.cs
@@ -1,3 +1,5 @@
+using GSCLSP.Core.Indexing;
+using GSCLSP.Core.Models;
 using static GSCLSP.Core.Models.RegexPatterns;
 
 namespace GSCLSP.Server.Handlers;
@@ -81,6 +83,17 @@ internal static class GscHandlerCommon
 
         fieldName = line[start..end];
         return true;
+    }
+
+    public static GscLevelField? ResolveLevelField(GscIndexer indexer, string[] lines, string filePath, string fieldName)
+    {
+        var docMatches = GscIndexer.ScanLevelFields(lines, filePath)
+            .Where(f => f.Name.Equals(fieldName, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        return docMatches.FirstOrDefault(f => f.Value.Length > 0)
+            ?? docMatches.FirstOrDefault()
+            ?? indexer.ResolveLevelField(fieldName);
     }
 
     public static List<(int Start, int End)> GetCodeRanges(string line, ref bool inBlockComment)

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -393,14 +393,7 @@ public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore docume
         if (!GscHandlerCommon.TryGetLevelFieldAt(line, character, out var fieldName))
             return null;
 
-        var docMatches = GscIndexer.ScanLevelFields(lines, filePath)
-            .Where(f => f.Name.Equals(fieldName, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        var field = docMatches.FirstOrDefault(f => f.Value.Length > 0)
-            ?? docMatches.FirstOrDefault()
-            ?? _indexer.ResolveLevelField(fieldName);
-
+        var field = GscHandlerCommon.ResolveLevelField(_indexer, lines, filePath, fieldName);
         if (field == null) return null;
 
         var signature = field.Value.Length > 0

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -94,6 +94,9 @@ public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore docume
         // for expression directives, we dont need anything else so early return here
         if (isExpressionDirective) return null;
 
+        var levelFieldHover = FindLevelField(filePath, lines, line, request.Position.Character);
+        if (levelFieldHover != null) return levelFieldHover;
+
         var globalVarHover = FindGlobalVariable(filePath, identifier);
         if (globalVarHover != null) return globalVarHover;
 
@@ -383,6 +386,33 @@ public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore docume
         var contentValue = $"```gsc\n#define {identifier}\n```\n---\n*(gsc-tool Preprocessor)*";
         var markupContent = new MarkupContent { Kind = MarkupKind.Markdown, Value = contentValue };
         return new Hover { Contents = new MarkedStringsOrMarkupContent(markupContent) };
+    }
+
+    private Hover? FindLevelField(string filePath, string[] lines, string line, int character)
+    {
+        if (!GscHandlerCommon.TryGetLevelFieldAt(line, character, out var fieldName))
+            return null;
+
+        var docMatches = GscIndexer.ScanLevelFields(lines, filePath)
+            .Where(f => f.Name.Equals(fieldName, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var field = docMatches.FirstOrDefault(f => f.Value.Length > 0)
+            ?? docMatches.FirstOrDefault()
+            ?? _indexer.ResolveLevelField(fieldName);
+
+        if (field == null) return null;
+
+        var signature = field.Value.Length > 0
+            ? $"level.{field.Name} = {field.Value}"
+            : $"level.{field.Name}";
+
+        var defLines = field.FilePath.Equals(filePath, StringComparison.OrdinalIgnoreCase)
+            ? lines
+            : _indexer.GetFileLines(field.FilePath);
+        var comment = GetDefinitionComment(defLines, field.LineNumber - 1);
+
+        return BuildDefinitionHover(signature, comment, "Level Field", field.FilePath, field.LineNumber);
     }
 
     private Hover? FindGlobalVariable(string filePath, string identifier)


### PR DESCRIPTION
closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for indexing and caching `level.*` fields across project files.
  - Added autocomplete suggestions for level fields, including values and source details.
  - Added navigation to level-field definitions.
  - Added hover information showing level-field signatures, values and documentation.

- **Bug Fixes**
  - Ensured level-field caches are refreshed and cleared alongside other indexed data.
  - Improved resolution by preferring locally defined, non-empty level-field values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->