### PR TITLE
add extending of builtins list per game & config

### DIFF
--- a/GSCLSP.Core/Indexing/BuiltInProvider.cs
+++ b/GSCLSP.Core/Indexing/BuiltInProvider.cs
@@ -16,6 +16,11 @@ public class BuiltInProvider(ILogger logger)
         new Dictionary<string, GscSymbol>(StringComparer.OrdinalIgnoreCase),
         new Dictionary<string, GscSymbol>(StringComparer.OrdinalIgnoreCase));
 
+    private Dictionary<string, GscSymbol> _baseFunctions = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, GscSymbol> _baseMethods = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, GscSymbol> _extensionFunctions = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, GscSymbol> _extensionMethods = new(StringComparer.OrdinalIgnoreCase);
+
     public void LoadBuiltIns(string jsonPath)
     {
         if (!File.Exists(jsonPath))
@@ -81,12 +86,17 @@ public class BuiltInProvider(ILogger logger)
             var isVariadic = VariadicBuiltIns.Contains(name);
             var parms = ReadArgs(element, name, minArgs, maxArgs, isVariadic);
 
+            var documentation = string.Empty;
+            if (element.TryGetProperty("description", out var descriptionElement) && descriptionElement.ValueKind == JsonValueKind.String)
+                documentation = descriptionElement.GetString() ?? string.Empty;
+
             target[name] = new GscSymbol(
                 name,
                 "Engine",
                 0,
                 parms,
                 symbolType,
+                Documentation: documentation,
                 MinArgs: minArgs,
                 MaxArgs: maxArgs,
                 IsVariadic: isVariadic
@@ -210,8 +220,51 @@ public class BuiltInProvider(ILogger logger)
         ReplaceSnapshot(builtInFunctions, builtInMethods);
     }
 
+    public void SetWorkspaceExtensions(JsonElement? root)
+    {
+        var extensionFunctions = new Dictionary<string, GscSymbol>(StringComparer.OrdinalIgnoreCase);
+        var extensionMethods = new Dictionary<string, GscSymbol>(StringComparer.OrdinalIgnoreCase);
+
+        if (root is { ValueKind: JsonValueKind.Object } element)
+        {
+            if (element.TryGetProperty("functions", out var functions) && functions.ValueKind == JsonValueKind.Array)
+                LoadEntries(functions, extensionFunctions, SymbolType.Function);
+
+            if (element.TryGetProperty("methods", out var methods) && methods.ValueKind == JsonValueKind.Array)
+                LoadEntries(methods, extensionMethods, SymbolType.Method);
+        }
+
+        _extensionFunctions = extensionFunctions;
+        _extensionMethods = extensionMethods;
+        RebuildSnapshot();
+
+        if (extensionFunctions.Count > 0 || extensionMethods.Count > 0)
+            logger.LogInformation("Applied {FunctionCount} workspace built-in function extension(s) and {MethodCount} method extension(s).", extensionFunctions.Count, extensionMethods.Count);
+    }
+
     private void ReplaceSnapshot(Dictionary<string, GscSymbol> functions, Dictionary<string, GscSymbol> methods)
     {
+        _baseFunctions = functions;
+        _baseMethods = methods;
+        RebuildSnapshot();
+    }
+
+    private void RebuildSnapshot()
+    {
+        var functions = _baseFunctions;
+        var methods = _baseMethods;
+
+        if (_extensionFunctions.Count > 0 || _extensionMethods.Count > 0)
+        {
+            functions = new Dictionary<string, GscSymbol>(functions, StringComparer.OrdinalIgnoreCase);
+            foreach (var (name, symbol) in _extensionFunctions)
+                functions[name] = symbol;
+
+            methods = new Dictionary<string, GscSymbol>(methods, StringComparer.OrdinalIgnoreCase);
+            foreach (var (name, symbol) in _extensionMethods)
+                methods[name] = symbol;
+        }
+
         Interlocked.Exchange(ref _snapshot, new BuiltInSnapshot(functions, methods));
     }
 

--- a/GSCLSP.Core/Indexing/BuiltInProvider.cs
+++ b/GSCLSP.Core/Indexing/BuiltInProvider.cs
@@ -20,6 +20,7 @@ public class BuiltInProvider(ILogger logger)
     private Dictionary<string, GscSymbol> _baseMethods = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<string, GscSymbol> _extensionFunctions = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<string, GscSymbol> _extensionMethods = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _rebuildLock = new();
 
     public void LoadBuiltIns(string jsonPath)
     {
@@ -234,9 +235,12 @@ public class BuiltInProvider(ILogger logger)
                 LoadEntries(methods, extensionMethods, SymbolType.Method);
         }
 
-        _extensionFunctions = extensionFunctions;
-        _extensionMethods = extensionMethods;
-        RebuildSnapshot();
+        lock (_rebuildLock)
+        {
+            _extensionFunctions = extensionFunctions;
+            _extensionMethods = extensionMethods;
+            RebuildSnapshot();
+        }
 
         if (extensionFunctions.Count > 0 || extensionMethods.Count > 0)
             logger.LogInformation("Applied {FunctionCount} workspace built-in function extension(s) and {MethodCount} method extension(s).", extensionFunctions.Count, extensionMethods.Count);
@@ -244,9 +248,12 @@ public class BuiltInProvider(ILogger logger)
 
     private void ReplaceSnapshot(Dictionary<string, GscSymbol> functions, Dictionary<string, GscSymbol> methods)
     {
-        _baseFunctions = functions;
-        _baseMethods = methods;
-        RebuildSnapshot();
+        lock (_rebuildLock)
+        {
+            _baseFunctions = functions;
+            _baseMethods = methods;
+            RebuildSnapshot();
+        }
     }
 
     private void RebuildSnapshot()

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -1206,7 +1206,7 @@ public partial class GscIndexer(ILogger logger)
 
         try
         {
-            LoadConfiguredBuiltIns(hasWorkspaceConfig, workspaceConfig?.Game, workspaceConfig?.GscToolRepository);
+            LoadConfiguredBuiltIns(hasWorkspaceConfig, workspaceConfig?.Game, workspaceConfig?.GscToolRepository, workspaceConfig?.BuiltIns);
         }
         catch (Exception ex)
         {
@@ -1252,7 +1252,7 @@ public partial class GscIndexer(ILogger logger)
 
     private static readonly TimeSpan GscToolCacheMaxAge = TimeSpan.FromDays(7);
 
-    private void LoadConfiguredBuiltIns(bool hasWorkspaceConfig, string? workspaceGame, string? workspaceGscToolRepository)
+    private void LoadConfiguredBuiltIns(bool hasWorkspaceConfig, string? workspaceGame, string? workspaceGscToolRepository, IReadOnlyDictionary<string, JsonElement>? workspaceBuiltIns)
     {
         var game = ResolveGameValue(hasWorkspaceConfig, workspaceGame);
         var normalizedGame = string.IsNullOrWhiteSpace(game)
@@ -1261,6 +1261,19 @@ public partial class GscIndexer(ILogger logger)
 
         var gameChanged = !string.Equals(CurrentGame, normalizedGame, StringComparison.Ordinal);
         CurrentGame = normalizedGame;
+
+        var previousBuiltIns = SnapshotBuiltIns();
+
+        JsonElement? extensions = null;
+        if (workspaceBuiltIns != null && workspaceBuiltIns.TryGetValue(normalizedGame, out var extensionsElement))
+            extensions = extensionsElement;
+        BuiltIns.SetWorkspaceExtensions(extensions);
+
+        void NotifyIfChanged()
+        {
+            if (gameChanged || !BuiltInSetsEqual(previousBuiltIns, SnapshotBuiltIns()))
+                GameChanged?.Invoke(normalizedGame);
+        }
 
         var basePath = AppDomain.CurrentDomain.BaseDirectory;
         var dataPath = Path.Combine(basePath, "data");
@@ -1272,7 +1285,7 @@ public partial class GscIndexer(ILogger logger)
         {
             BuiltIns.LoadBuiltIns(requestedPath);
             _logger.LogInformation("Loaded builtins for game '{Game}'.", normalizedGame);
-            if (gameChanged) GameChanged?.Invoke(normalizedGame);
+            NotifyIfChanged();
             return;
         }
 
@@ -1284,16 +1297,9 @@ public partial class GscIndexer(ILogger logger)
             var cached = GscToolBuiltInsLoader.TryLoadFromCache(normalizedGame, source);
             if (cached != null)
             {
-                var previousFunctions = SnapshotBuiltInNames(SymbolType.Function);
-                var previousMethods = SnapshotBuiltInNames(SymbolType.Method);
-
                 BuiltIns.LoadNameOnlyBuiltIns(cached.Functions, cached.Methods, cached.Tokens);
                 _logger.LogDebug("Loaded cached builtins for game '{Game}'{SourceLabel}.", normalizedGame, sourceLabel);
-
-                var builtInsChanged = !BuiltInNamesEqual(previousFunctions, cached.Functions)
-                                   || !BuiltInNamesEqual(previousMethods, cached.Methods);
-
-                if (gameChanged || builtInsChanged) GameChanged?.Invoke(normalizedGame);
+                NotifyIfChanged();
 
                 if (GscToolBuiltInsLoader.IsCacheStale(normalizedGame, source, GscToolCacheMaxAge))
                     _ = RefreshGscToolBuiltInsAsync(normalizedGame, source);
@@ -1302,7 +1308,7 @@ public partial class GscIndexer(ILogger logger)
             {
                 BuiltIns.LoadNameOnlyBuiltIns([], [], []);
                 _logger.LogDebug("No cached builtins for game '{Game}'{SourceLabel}, fetching from gsc-tool...", normalizedGame, sourceLabel);
-                if (gameChanged) GameChanged?.Invoke(normalizedGame);
+                NotifyIfChanged();
                 _ = RefreshGscToolBuiltInsAsync(normalizedGame, source);
             }
             return;
@@ -1316,12 +1322,12 @@ public partial class GscIndexer(ILogger logger)
         if (File.Exists(fallbackPath))
         {
             BuiltIns.LoadBuiltIns(fallbackPath);
-            if (gameChanged) GameChanged?.Invoke(normalizedGame);
+            NotifyIfChanged();
             return;
         }
 
         _logger.LogDebug("No builtins file found for game '{Game}', expected data/iw4_builtins.json", normalizedGame);
-        if (gameChanged) GameChanged?.Invoke(normalizedGame);
+        NotifyIfChanged();
     }
 
     private async Task RefreshGscToolBuiltInsAsync(string game, GscToolSource source)
@@ -1336,19 +1342,14 @@ public partial class GscIndexer(ILogger logger)
         if (!string.Equals(CurrentGame, game, StringComparison.OrdinalIgnoreCase))
             return;
 
-        var previousFunctions = SnapshotBuiltInNames(SymbolType.Function);
-        var previousMethods = SnapshotBuiltInNames(SymbolType.Method);
-        var builtInsChanged = !BuiltInNamesEqual(previousFunctions, fetched.Functions)
-            || !BuiltInNamesEqual(previousMethods, fetched.Methods);
-
+        var previousBuiltIns = SnapshotBuiltIns();
         BuiltIns.LoadNameOnlyBuiltIns(fetched.Functions, fetched.Methods, fetched.Tokens);
         _logger.LogDebug("Refreshed builtins for game '{Game}' from {Source}.", game, source.DisplayName);
-        if (builtInsChanged)
+        if (!BuiltInSetsEqual(previousBuiltIns, SnapshotBuiltIns()))
             GameChanged?.Invoke(game);
     }
 
-    private string[] SnapshotBuiltInNames(SymbolType symbolType) =>
-        [..BuiltIns.GetAll().Where(s => s.Type == symbolType).Select(s => s.Name)];
+    private GscSymbol[] SnapshotBuiltIns() => [..BuiltIns.GetAll()];
 
     private static GscToolSource ResolveGscToolSource(string? raw)
     {
@@ -1361,10 +1362,9 @@ public partial class GscIndexer(ILogger logger)
         return GscToolSource.Default;
     }
 
-    private static bool BuiltInNamesEqual(IEnumerable<string> left, IEnumerable<string> right)
+    private static bool BuiltInSetsEqual(IEnumerable<GscSymbol> left, IEnumerable<GscSymbol> right)
     {
-        return new HashSet<string>(left, StringComparer.OrdinalIgnoreCase)
-            .SetEquals(right);
+        return new HashSet<GscSymbol>(left).SetEquals(right);
     }
 
     private static string ResolveGameValue(bool hasWorkspaceConfig, string? workspaceGame)
@@ -1378,7 +1378,8 @@ public partial class GscIndexer(ILogger logger)
     private sealed record WorkspaceConfig(
         IReadOnlyDictionary<string, string>? DumpPaths,
         string? Game,
-        string? GscToolRepository);
+        string? GscToolRepository,
+        IReadOnlyDictionary<string, JsonElement>? BuiltIns);
 
     private static (bool HasConfigFile, WorkspaceConfig? Config) TryReadWorkspaceConfig(string? workspacePath)
     {
@@ -1425,7 +1426,18 @@ public partial class GscIndexer(ILogger logger)
             if (root.TryGetProperty("gsc_tool_repository", out var gscToolRepositoryProperty) && gscToolRepositoryProperty.ValueKind == JsonValueKind.String)
                 gscToolRepository = gscToolRepositoryProperty.GetString();
 
-            return new WorkspaceConfig(dumpPaths, game, gscToolRepository);
+            Dictionary<string, JsonElement>? builtIns = null;
+            if (root.TryGetProperty("builtins", out var builtInsProperty) && builtInsProperty.ValueKind == JsonValueKind.Object)
+            {
+                builtIns = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+                foreach (var entry in builtInsProperty.EnumerateObject())
+                {
+                    if (entry.Value.ValueKind == JsonValueKind.Object)
+                        builtIns[entry.Name] = entry.Value.Clone();
+                }
+            }
+
+            return new WorkspaceConfig(dumpPaths, game, gscToolRepository, builtIns);
         }
         catch { }
 

--- a/GSCLSP.Extension/README.md
+++ b/GSCLSP.Extension/README.md
@@ -73,6 +73,34 @@ Dump folders are used per game by `dumpPaths` in the config. The current `game` 
 }
 ```
 
+## Custom Built-ins
+
+You can extend the built-in function/method list per game with the `builtins` key in the config. Entries show up in autocompletion, hover, and are recognized by diagnostics — and they override a shipped built-in of the same name.
+
+```json
+{
+  "game": "iw4",
+  "builtins": {
+    "iw4": {
+      "functions": [
+        {
+          "name": "mycustomfunc",
+          "description": "Added by my mod's engine patch.",
+          "args": ["player", "value"],
+          "minArgs": 1,
+          "maxArgs": 2
+        }
+      ],
+      "methods": [
+        { "name": "mycustommethod" }
+      ]
+    }
+  }
+}
+```
+
+Only the block matching the active `game` is applied. All fields except `name` are optional; `args` may also use the object form `{ "name": "player", "description": "..." }`.
+
 ## Choosing Your Target Game
 
 Once you are inside a valid _GSC_ file, you will see a `GSC Target Game` dropbox appear in the **bottom right corner.** Choosing the game you are working on will help GSCLSP change the built-ins list and gives accurate diagnostics.

--- a/GSCLSP.Server/Handlers/GscCompletionItemFactory.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionItemFactory.cs
@@ -83,6 +83,10 @@ internal static class GscCompletionItemFactory
 
         var paramDetail = GetParameterDetail(symbol, parsedArgs);
 
+        var documentationValue = $"**Source:** `{Path.GetFileName(symbol.FilePath)}`";
+        if (!string.IsNullOrEmpty(symbol.Documentation))
+            documentationValue = $"{symbol.Documentation}\n\n{documentationValue}";
+
         return new SymbolCompletionCache
         {
             ParamDetail = paramDetail,
@@ -91,7 +95,7 @@ internal static class GscCompletionItemFactory
             Documentation = new StringOrMarkupContent(new MarkupContent
             {
                 Kind = MarkupKind.Markdown,
-                Value = $"**Source:** `{Path.GetFileName(symbol.FilePath)}`"
+                Value = documentationValue
             })
         };
     }


### PR DESCRIPTION
closes #23 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for workspace-defined custom built-in functions and methods via `gsclsp.config.json`.
  * Custom built-ins are shown in autocompletion and hover, recognised by diagnostics, and can override shipped entries for the active game.
  * Built-in descriptions are now included in completion details.

* **Documentation**
  * Documented the new `builtins` configuration, including per-game selection and optional argument metadata.

* **Bug Fixes**
  * Improved built-in refresh and change detection so updates are applied reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->