### PR TITLE
add source checking for GSC magic (compiled)

### DIFF
--- a/GSCLSP.Benchmark/GscReferencesHandlerBenchmark.cs
+++ b/GSCLSP.Benchmark/GscReferencesHandlerBenchmark.cs
@@ -21,7 +21,7 @@ public class GscReferencesHandlerBenchmark
     public void Setup()
     {
         _indexer = new GscIndexer(Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
-        _referencesHandler = new GscReferencesHandler(_indexer, null);
+        _referencesHandler = new GscReferencesHandler(_indexer, new GscDocumentStore(), null);
         // Create test workspace
         string tempDir = Path.Combine(Path.GetTempPath(), "gsclsp-references-" + Guid.NewGuid());
         Directory.CreateDirectory(tempDir);

--- a/GSCLSP.Core.Tests/GSCLSP.Core.Tests.csproj
+++ b/GSCLSP.Core.Tests/GSCLSP.Core.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GSCLSP.Core\GSCLSP.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/GSCLSP.Core.Tests/GscCompiledScriptDetectorTests.cs
+++ b/GSCLSP.Core.Tests/GscCompiledScriptDetectorTests.cs
@@ -1,0 +1,138 @@
+using GSCLSP.Core.Models;
+
+namespace GSCLSP.Core.Tests;
+
+public class GscCompiledScriptDetectorTests
+{
+    private const char Magic = (char)0x80;
+    private const char Replacement = (char)0xFFFD;
+
+    [Fact]
+    public void IsCompiledText_RawMagic_ReturnsTrue()
+    {
+        Assert.True(GscCompiledScriptDetector.IsCompiledText(Magic + "GSCbinary"));
+    }
+
+    [Fact]
+    public void IsCompiledText_DecodedMagic_ReturnsTrue()
+    {
+        Assert.True(GscCompiledScriptDetector.IsCompiledText(Replacement + "GSCbinary"));
+    }
+
+    [Fact]
+    public void IsCompiledText_BinaryGarbageWithoutMagic_ReturnsTrue()
+    {
+        var text = new string('a', 100) + new string('\0', 20) + new string('b', 100);
+        Assert.True(GscCompiledScriptDetector.IsCompiledText(text));
+    }
+
+    [Fact]
+    public void IsCompiledText_NormalSource_ReturnsFalse()
+    {
+        const string source = """
+            #include maps\mp\_utility;
+
+            init()
+            {
+                level thread on_player_connect();
+            }
+            """;
+
+        Assert.False(GscCompiledScriptDetector.IsCompiledText(source));
+    }
+
+    [Fact]
+    public void IsCompiledText_ShortSource_ReturnsFalse()
+    {
+        Assert.False(GscCompiledScriptDetector.IsCompiledText("init(){}"));
+    }
+
+    [Fact]
+    public void IsCompiledText_Empty_ReturnsFalse()
+    {
+        Assert.False(GscCompiledScriptDetector.IsCompiledText(string.Empty));
+    }
+
+    [Fact]
+    public void IsCompiledText_WhitespaceOnly_ReturnsFalse()
+    {
+        Assert.False(GscCompiledScriptDetector.IsCompiledText("  \r\n\t\r\n  "));
+    }
+
+    [Fact]
+    public void IsCompiledText_MagicPrefixOnly_ReturnsFalse()
+    {
+        Assert.False(GscCompiledScriptDetector.IsCompiledText("GSC init(){}"));
+    }
+
+    [Fact]
+    public void IsCompiledFile_MagicBytes_ReturnsTrue()
+    {
+        var path = WriteTempFile([0x80, (byte)'G', (byte)'S', (byte)'C', 0x01, 0x02, 0x03]);
+        try
+        {
+            Assert.True(GscCompiledScriptDetector.IsCompiledFile(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsCompiledFile_NulBytesWithoutMagic_ReturnsTrue()
+    {
+        var path = WriteTempFile([(byte)'i', (byte)'n', (byte)'i', (byte)'t', 0x00, (byte)'x']);
+        try
+        {
+            Assert.True(GscCompiledScriptDetector.IsCompiledFile(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsCompiledFile_PlainSource_ReturnsFalse()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".gsc");
+        File.WriteAllText(path, "init()\n{\n    level.foo = 1;\n}\n");
+        try
+        {
+            Assert.False(GscCompiledScriptDetector.IsCompiledFile(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsCompiledFile_EmptyFile_ReturnsFalse()
+    {
+        var path = WriteTempFile([]);
+        try
+        {
+            Assert.False(GscCompiledScriptDetector.IsCompiledFile(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsCompiledFile_MissingFile_ReturnsFalse()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".gsc");
+        Assert.False(GscCompiledScriptDetector.IsCompiledFile(path));
+    }
+
+    private static string WriteTempFile(byte[] bytes)
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".gsc");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+}

--- a/GSCLSP.Core/Indexing/GscIndexer.LevelFields.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.LevelFields.cs
@@ -64,6 +64,9 @@ public partial class GscIndexer
 
         foreach (var file in files)
         {
+            if (GscCompiledScriptDetector.IsCompiledFile(file))
+                continue;
+
             try
             {
                 foreach (var field in ScanLevelFields(File.ReadAllLines(file), file))

--- a/GSCLSP.Core/Indexing/GscIndexer.LevelFields.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.LevelFields.cs
@@ -104,8 +104,14 @@ public partial class GscIndexer
             var fields = JsonSerializer.Deserialize(File.ReadAllText(jsonPath), GscJsonContext.Default.ListGscLevelField);
             if (fields == null) return;
 
+            var compiledMemo = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             foreach (var field in fields)
+            {
+                if (IsCompiledCachedPath(field.FilePath, compiledMemo))
+                    continue;
+
                 AddDumpLevelField(field);
+            }
 
             _logger.LogDebug("Indexer loaded {Count} level fields from JSON.", fields.Count);
         }

--- a/GSCLSP.Core/Indexing/GscIndexer.Workspace.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.Workspace.cs
@@ -27,6 +27,9 @@ public partial class GscIndexer
 
         foreach (var file in files)
         {
+            if (GscCompiledScriptDetector.IsCompiledFile(file))
+                continue;
+
             string normalizedPath = NormalizePathKey(file);
             var parsed = ParseWorkspaceFileForIncrementalIndex(file);
 
@@ -168,7 +171,7 @@ public partial class GscIndexer
             if (_workspaceFileMaps.TryGetValue(normalizedPath, out var oldMap) && oldMap.OverridePath != null)
                 _workspaceOverrides.Remove(oldMap.OverridePath);
 
-            if (File.Exists(filePath))
+            if (File.Exists(filePath) && !GscCompiledScriptDetector.IsCompiledFile(filePath))
             {
                 try
                 {

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -189,6 +189,9 @@ public partial class GscIndexer(ILogger logger)
 
     private void ParseFile(string path)
     {
+        if (GscCompiledScriptDetector.IsCompiledFile(path))
+            return;
+
         var fileMap = new GscFileMap { FilePath = path };
         var lines = File.ReadAllLines(path);
 

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -173,9 +173,14 @@ public partial class GscIndexer(ILogger logger)
 
         if (symbols != null)
         {
-            _symbols.AddRange(symbols);
+            var compiledMemo = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             foreach (var s in symbols)
             {
+                if (IsCompiledCachedPath(s.FilePath, compiledMemo))
+                    continue;
+
+                _symbols.Add(s);
+
                 if (!_fileMaps.ContainsKey(s.FilePath))
                     _fileMaps[s.FilePath] = new GscFileMap { FilePath = s.FilePath };
 
@@ -185,6 +190,14 @@ public partial class GscIndexer(ILogger logger)
 
 
         _logger.LogDebug("Indexer loaded {Count} GSC symbols from JSON.", _symbols.Count);
+    }
+
+    internal static bool IsCompiledCachedPath(string filePath, Dictionary<string, bool> memo)
+    {
+        if (!memo.TryGetValue(filePath, out var compiled))
+            memo[filePath] = compiled = File.Exists(filePath) && GscCompiledScriptDetector.IsCompiledFile(filePath);
+
+        return compiled;
     }
 
     private void ParseFile(string path)

--- a/GSCLSP.Core/Models/GscCompiledScriptDetector.cs
+++ b/GSCLSP.Core/Models/GscCompiledScriptDetector.cs
@@ -1,0 +1,82 @@
+namespace GSCLSP.Core.Models;
+
+public static class GscCompiledScriptDetector
+{
+    private const int SampleLength = 512;
+    private const double BinaryRatioThreshold = 0.05;
+    private const char CompiledMagicChar = (char)0x80;
+    private const char ReplacementChar = (char)0xFFFD;
+
+    public static bool IsCompiledText(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        if (HasMagic(text))
+            return true;
+
+        int examined = Math.Min(text.Length, SampleLength);
+        int binary = 0;
+
+        for (int i = 0; i < examined; i++)
+        {
+            if (IsBinaryIndicator(text[i]))
+                binary++;
+        }
+
+        return binary > examined * BinaryRatioThreshold;
+    }
+
+    public static bool IsCompiledFile(string path)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+
+            Span<byte> buffer = stackalloc byte[SampleLength];
+            int read = stream.ReadAtLeast(buffer, SampleLength, throwOnEndOfStream: false);
+            if (read <= 0)
+                return false;
+
+            var sample = buffer[..read];
+
+            if (sample.Length >= 4 && sample[0] == 0x80 && sample[1] == (byte)'G' && sample[2] == (byte)'S' && sample[3] == (byte)'C')
+                return true;
+
+            return sample.IndexOf((byte)0) >= 0;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (System.Security.SecurityException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasMagic(string text)
+    {
+        return text.Length >= 4
+            && (text[0] == CompiledMagicChar || text[0] == ReplacementChar)
+            && text[1] == 'G'
+            && text[2] == 'S'
+            && text[3] == 'C';
+    }
+
+    private static bool IsBinaryIndicator(char c)
+    {
+        if (c == '\0' || c == ReplacementChar)
+            return true;
+
+        return char.IsControl(c) && c != '\t' && c != '\r' && c != '\n';
+    }
+}

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -18,6 +18,9 @@ import {
   Range,
   Uri,
   LogLevel,
+  languages,
+  type LanguageStatusItem,
+  LanguageStatusSeverity,
 } from "vscode";
 import {
   LanguageClient,
@@ -31,6 +34,8 @@ let client: LanguageClient;
 let targetGameStatusBar: StatusBarItem | undefined;
 let inactiveDecoration: TextEditorDecorationType | undefined;
 const inactiveRangesByUri = new Map<string, Range[]>();
+let compiledStatusItem: LanguageStatusItem | undefined;
+const compiledUris = new Set<string>();
 
 // games that GSCLSP can work on no problem, but they may use IW4 builtins for now
 const KNOWN_GAMES = [
@@ -188,6 +193,42 @@ function handleInactiveRegions(params: InactiveRegionsParams): void {
       applyDecorationsFor(editor);
     }
   }
+}
+
+interface CompiledScriptParams {
+  uri: string;
+  compiled: boolean;
+}
+
+function refreshCompiledStatus(): void {
+  const activeUri = window.activeTextEditor?.document.uri.toString();
+
+  if (!activeUri || !compiledUris.has(activeUri)) {
+    compiledStatusItem?.dispose();
+    compiledStatusItem = undefined;
+    return;
+  }
+
+  if (!compiledStatusItem) {
+    compiledStatusItem = languages.createLanguageStatusItem("gsclsp.compiledScript", {
+      scheme: "file",
+      language: "gsc",
+    });
+  }
+
+  compiledStatusItem.severity = LanguageStatusSeverity.Warning;
+  compiledStatusItem.text = "$(circle-slash) Compiled GSC";
+  compiledStatusItem.detail = "Compiled script — language features disabled";
+}
+
+function handleCompiledScript(params: CompiledScriptParams): void {
+  const key = Uri.parse(params.uri).toString();
+  if (params.compiled) {
+    compiledUris.add(key);
+  } else {
+    compiledUris.delete(key);
+  }
+  refreshCompiledStatus();
 }
 
 async function ensureWorkspaceConfigFile(folder: WorkspaceFolder): Promise<void> {
@@ -413,13 +454,29 @@ export async function activate(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(client.onNotification("custom/dumpStatus", handleDumpStatus));
 
   context.subscriptions.push(
+    client.onNotification("custom/compiledScript", handleCompiledScript),
+    {
+      dispose: () => {
+        compiledStatusItem?.dispose();
+        compiledStatusItem = undefined;
+        compiledUris.clear();
+      },
+    },
+  );
+
+  context.subscriptions.push(
     workspace.onDidCloseTextDocument((doc) => {
-      inactiveRangesByUri.delete(doc.uri.toString());
+      const key = doc.uri.toString();
+      inactiveRangesByUri.delete(key);
+      compiledUris.delete(key);
     }),
   );
 
   context.subscriptions.push(
-    window.onDidChangeActiveTextEditor((editor) => applyDecorationsFor(editor)),
+    window.onDidChangeActiveTextEditor((editor) => {
+      applyDecorationsFor(editor);
+      refreshCompiledStatus();
+    }),
     window.onDidChangeVisibleTextEditors((editors) => {
       for (const e of editors) applyDecorationsFor(e);
     }),

--- a/GSCLSP.Extension/src/extension.ts
+++ b/GSCLSP.Extension/src/extension.ts
@@ -393,6 +393,17 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   context.subscriptions.push(client);
 
+  context.subscriptions.push(
+    client.onNotification("custom/compiledScript", handleCompiledScript),
+    {
+      dispose: () => {
+        compiledStatusItem?.dispose();
+        compiledStatusItem = undefined;
+        compiledUris.clear();
+      },
+    },
+  );
+
   await client.start();
 
   // Register MCP Server
@@ -452,17 +463,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
   );
 
   context.subscriptions.push(client.onNotification("custom/dumpStatus", handleDumpStatus));
-
-  context.subscriptions.push(
-    client.onNotification("custom/compiledScript", handleCompiledScript),
-    {
-      dispose: () => {
-        compiledStatusItem?.dispose();
-        compiledStatusItem = undefined;
-        compiledUris.clear();
-      },
-    },
-  );
 
   context.subscriptions.push(
     workspace.onDidCloseTextDocument((doc) => {

--- a/GSCLSP.Server/Handlers/GscCodeActionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCodeActionHandler.cs
@@ -15,7 +15,7 @@ public class GscCodeActionHandler(GscDocumentStore documentStore, GscDiagnostics
     {
         var uri = request.TextDocument.Uri;
         var text = _documentStore.Get(uri);
-        if (string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(text) || _documentStore.IsCompiled(uri))
             return new CommandOrCodeActionContainer();
 
         var actions = new List<CommandOrCodeAction>();

--- a/GSCLSP.Server/Handlers/GscCompletionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionHandler.cs
@@ -26,6 +26,8 @@ namespace GSCLSP.Server.Handlers
             var currentFilePath = uri.GetFileSystemPath();
 
             var content = _documentStore.Get(uri) ?? _indexer.GetFileContent(currentFilePath);
+            if (GscCompiledScriptDetector.IsCompiledText(content)) return new CompletionList();
+
             var currentFileLines = content.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
 
             if (request.Position.Line >= currentFileLines.Length) return new CompletionList();

--- a/GSCLSP.Server/Handlers/GscDefinitionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDefinitionHandler.cs
@@ -32,7 +32,7 @@ public class GscDefinitionHandler(GscIndexer indexer, GscDocumentStore documentS
         var userDumpPath = _indexer.DumpPath;
 
         var content = _documentStore.Get(uri) ?? _indexer.GetFileContent(currentFilePath);
-        if (string.IsNullOrEmpty(content)) return new DefinitionResult();
+        if (string.IsNullOrEmpty(content) || GscCompiledScriptDetector.IsCompiledText(content)) return new DefinitionResult();
 
         var lines = content.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
         if (request.Position.Line >= lines.Length) return new DefinitionResult();

--- a/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 using static GSCLSP.Core.Models.RegexPatterns;
 
@@ -22,7 +21,8 @@ public class GscDiagnosticsHandler : IDisposable
     private readonly GscDiagnosticsAnalyzer _diagnosticsAnalyzer;
     private readonly ILanguageServerFacade _languageServer;
     private readonly GscDocumentStore _documentStore;
-    private readonly ConcurrentDictionary<string, bool> _compiledStateNotified = new();
+    private readonly Dictionary<string, bool> _compiledStateNotified = new();
+    private readonly object _compiledStateLock = new();
     private CancellationTokenSource? _republishCancellationTokenSource;
     private readonly ILogger<GscDiagnosticsHandler> _logger;
     private readonly Action<string> _onGameChanged;
@@ -156,7 +156,10 @@ public class GscDiagnosticsHandler : IDisposable
 
     public async Task PublishFromDiskAsync(DocumentUri uri, CancellationToken cancellationToken)
     {
-        _compiledStateNotified.TryRemove(uri.ToString(), out _);
+        lock (_compiledStateLock)
+        {
+            _compiledStateNotified.Remove(uri.ToString());
+        }
 
         var filePath = uri.GetFileSystemPath();
         if (!File.Exists(filePath))
@@ -225,19 +228,22 @@ public class GscDiagnosticsHandler : IDisposable
     {
         var key = uri.ToString();
 
-        if (_compiledStateNotified.TryGetValue(key, out var previous))
+        lock (_compiledStateLock)
         {
-            if (previous == compiled)
+            if (_compiledStateNotified.TryGetValue(key, out var previous))
+            {
+                if (previous == compiled)
+                    return;
+            }
+            else if (!compiled)
+            {
+                _compiledStateNotified[key] = false;
                 return;
-        }
-        else if (!compiled)
-        {
-            _compiledStateNotified[key] = false;
-            return;
-        }
+            }
 
-        _compiledStateNotified[key] = compiled;
-        _languageServer.SendNotification("custom/compiledScript", new { uri = key, compiled });
+            _compiledStateNotified[key] = compiled;
+            _languageServer.SendNotification("custom/compiledScript", new { uri = key, compiled });
+        }
     }
 
     public Task ClearAsync(DocumentUri uri, CancellationToken cancellationToken)

--- a/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDiagnosticsHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 using static GSCLSP.Core.Models.RegexPatterns;
 
@@ -21,6 +22,7 @@ public class GscDiagnosticsHandler : IDisposable
     private readonly GscDiagnosticsAnalyzer _diagnosticsAnalyzer;
     private readonly ILanguageServerFacade _languageServer;
     private readonly GscDocumentStore _documentStore;
+    private readonly ConcurrentDictionary<string, bool> _compiledStateNotified = new();
     private CancellationTokenSource? _republishCancellationTokenSource;
     private readonly ILogger<GscDiagnosticsHandler> _logger;
     private readonly Action<string> _onGameChanged;
@@ -130,6 +132,12 @@ public class GscDiagnosticsHandler : IDisposable
             if (string.IsNullOrEmpty(text))
                 return;
 
+            if (GscCompiledScriptDetector.IsCompiledText(text))
+            {
+                await ClearAsync(DocumentUri.FromFileSystemPath(filePath), cancellationToken);
+                return;
+            }
+
             var diagnostics = await CollectDiagnosticsAsync(filePath, text, cancellationToken);
 
             _languageServer.SendNotification("textDocument/publishDiagnostics", new PublishDiagnosticsParams
@@ -148,6 +156,8 @@ public class GscDiagnosticsHandler : IDisposable
 
     public async Task PublishFromDiskAsync(DocumentUri uri, CancellationToken cancellationToken)
     {
+        _compiledStateNotified.TryRemove(uri.ToString(), out _);
+
         var filePath = uri.GetFileSystemPath();
         if (!File.Exists(filePath))
         {
@@ -160,6 +170,22 @@ public class GscDiagnosticsHandler : IDisposable
 
     public async Task PublishAsync(DocumentUri uri, string text, CancellationToken cancellationToken)
     {
+        if (GscCompiledScriptDetector.IsCompiledText(text))
+        {
+            await ClearAsync(uri, cancellationToken);
+
+            _languageServer.SendNotification("custom/inactiveRegions", new
+            {
+                uri = uri.ToString(),
+                ranges = Array.Empty<object>()
+            });
+
+            NotifyCompiledState(uri, true);
+            return;
+        }
+
+        NotifyCompiledState(uri, false);
+
         var diagnostics = await CollectDiagnosticsAsync(uri.GetFileSystemPath(), text, cancellationToken);
 
         _languageServer.SendNotification("textDocument/publishDiagnostics", new PublishDiagnosticsParams
@@ -193,6 +219,25 @@ public class GscDiagnosticsHandler : IDisposable
             uri = uri.ToString(),
             ranges
         });
+    }
+
+    private void NotifyCompiledState(DocumentUri uri, bool compiled)
+    {
+        var key = uri.ToString();
+
+        if (_compiledStateNotified.TryGetValue(key, out var previous))
+        {
+            if (previous == compiled)
+                return;
+        }
+        else if (!compiled)
+        {
+            _compiledStateNotified[key] = false;
+            return;
+        }
+
+        _compiledStateNotified[key] = compiled;
+        _languageServer.SendNotification("custom/compiledScript", new { uri = key, compiled });
     }
 
     public Task ClearAsync(DocumentUri uri, CancellationToken cancellationToken)

--- a/GSCLSP.Server/Handlers/GscDocumentSyncHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDocumentSyncHandler.cs
@@ -11,24 +11,19 @@ namespace GSCLSP.Server.Handlers;
 
 public class GscDocumentStore
 {
-    private readonly ConcurrentDictionary<DocumentUri, string> _documents = new();
-    private readonly ConcurrentDictionary<DocumentUri, bool> _compiled = new();
+    private sealed record DocumentSnapshot(string Text, bool Compiled);
 
-    public void Update(DocumentUri uri, string text)
-    {
-        _documents[uri] = text;
-        _compiled[uri] = GscCompiledScriptDetector.IsCompiledText(text);
-    }
+    private readonly ConcurrentDictionary<DocumentUri, DocumentSnapshot> _documents = new();
 
-    public void Remove(DocumentUri uri)
-    {
-        _documents.TryRemove(uri, out _);
-        _compiled.TryRemove(uri, out _);
-    }
+    public void Update(DocumentUri uri, string text) =>
+        _documents[uri] = new DocumentSnapshot(text, GscCompiledScriptDetector.IsCompiledText(text));
 
-    public string? Get(DocumentUri uri) => _documents.TryGetValue(uri, out var text) ? text : null;
-    public bool IsCompiled(DocumentUri uri) => _compiled.TryGetValue(uri, out var compiled) && compiled;
-    public IEnumerable<KeyValuePair<DocumentUri, string>> OpenDocuments => _documents;
+    public void Remove(DocumentUri uri) => _documents.TryRemove(uri, out _);
+
+    public string? Get(DocumentUri uri) => _documents.TryGetValue(uri, out var doc) ? doc.Text : null;
+    public bool IsCompiled(DocumentUri uri) => _documents.TryGetValue(uri, out var doc) && doc.Compiled;
+    public IEnumerable<KeyValuePair<DocumentUri, string>> OpenDocuments =>
+        _documents.Select(kv => new KeyValuePair<DocumentUri, string>(kv.Key, kv.Value.Text));
 }
 
 public class GscDocumentSyncHandler(GscDocumentStore store, Lazy<GscDiagnosticsHandler> diagnosticsHandler) : TextDocumentSyncHandlerBase

--- a/GSCLSP.Server/Handlers/GscDocumentSyncHandler.cs
+++ b/GSCLSP.Server/Handlers/GscDocumentSyncHandler.cs
@@ -1,3 +1,4 @@
+using GSCLSP.Core.Models;
 using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -11,10 +12,22 @@ namespace GSCLSP.Server.Handlers;
 public class GscDocumentStore
 {
     private readonly ConcurrentDictionary<DocumentUri, string> _documents = new();
+    private readonly ConcurrentDictionary<DocumentUri, bool> _compiled = new();
 
-    public void Update(DocumentUri uri, string text) => _documents[uri] = text;
-    public void Remove(DocumentUri uri) => _documents.TryRemove(uri, out _);
+    public void Update(DocumentUri uri, string text)
+    {
+        _documents[uri] = text;
+        _compiled[uri] = GscCompiledScriptDetector.IsCompiledText(text);
+    }
+
+    public void Remove(DocumentUri uri)
+    {
+        _documents.TryRemove(uri, out _);
+        _compiled.TryRemove(uri, out _);
+    }
+
     public string? Get(DocumentUri uri) => _documents.TryGetValue(uri, out var text) ? text : null;
+    public bool IsCompiled(DocumentUri uri) => _compiled.TryGetValue(uri, out var compiled) && compiled;
     public IEnumerable<KeyValuePair<DocumentUri, string>> OpenDocuments => _documents;
 }
 

--- a/GSCLSP.Server/Handlers/GscFormattingHandler.cs
+++ b/GSCLSP.Server/Handlers/GscFormattingHandler.cs
@@ -23,7 +23,7 @@ public class GscFormattingHandler(GscDocumentStore documentStore)
     public Task<TextEditContainer?> Handle(DocumentFormattingParams request, CancellationToken cancellationToken)
     {
         var content = _documentStore.Get(request.TextDocument.Uri);
-        if (string.IsNullOrEmpty(content))
+        if (string.IsNullOrEmpty(content) || _documentStore.IsCompiled(request.TextDocument.Uri))
             return Task.FromResult<TextEditContainer?>(null);
 
         var formatted = GscFormatter.Format(
@@ -65,7 +65,7 @@ public class GscRangeFormattingHandler(GscDocumentStore documentStore)
     public Task<TextEditContainer> Handle(DocumentRangeFormattingParams request, CancellationToken cancellationToken)
     {
         var content = _documentStore.Get(request.TextDocument.Uri);
-        if (string.IsNullOrEmpty(content))
+        if (string.IsNullOrEmpty(content) || _documentStore.IsCompiled(request.TextDocument.Uri))
             return Task.FromResult<TextEditContainer>(new TextEditContainer());
 
         var startLine = request.Range.Start.Line;

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -30,6 +30,8 @@ public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore docume
         var filePath = uri.GetFileSystemPath();
 
         var content = _documentStore.Get(uri) ?? _indexer.GetFileContent(filePath);
+        if (GscCompiledScriptDetector.IsCompiledText(content)) return null;
+
         var lines = content.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
         if (request.Position.Line >= lines.Length) return null;
 

--- a/GSCLSP.Server/Handlers/GscReferencesHandler.cs
+++ b/GSCLSP.Server/Handlers/GscReferencesHandler.cs
@@ -1,4 +1,5 @@
 ﻿using GSCLSP.Core.Indexing;
+using GSCLSP.Core.Models;
 using GSCLSP.Core.Parsing;
 using GSCLSP.Lexer;
 using Microsoft.Extensions.Configuration;
@@ -23,7 +24,7 @@ namespace GSCLSP.Server.Handlers
             string? normalizedDumpPath = GscIndexer.NormalizePath(rawDumpPath);
 
             string currentContent = _indexer.GetFileContent(currentFilePath);
-            if (string.IsNullOrEmpty(currentContent)) return new LocationContainer();
+            if (string.IsNullOrEmpty(currentContent) || GscCompiledScriptDetector.IsCompiledText(currentContent)) return new LocationContainer();
 
             var currentFileLines = currentContent.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
             var line = currentFileLines[request.Position.Line];

--- a/GSCLSP.Server/Handlers/GscReferencesHandler.cs
+++ b/GSCLSP.Server/Handlers/GscReferencesHandler.cs
@@ -10,9 +10,10 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace GSCLSP.Server.Handlers
 {
-    public class GscReferencesHandler(GscIndexer indexer, IConfiguration configuration) : IReferencesHandler
+    public class GscReferencesHandler(GscIndexer indexer, GscDocumentStore documentStore, IConfiguration configuration) : IReferencesHandler
     {
         private readonly GscIndexer _indexer = indexer;
+        private readonly GscDocumentStore _documentStore = documentStore;
         private readonly IConfiguration _configuration = configuration;
 
         public async Task<LocationContainer?> Handle(ReferenceParams request, CancellationToken cancellationToken)
@@ -23,7 +24,7 @@ namespace GSCLSP.Server.Handlers
             var rawDumpPath = _indexer.DumpPath ?? _configuration?.GetValue<string>("gsclsp:dumpPath");
             string? normalizedDumpPath = GscIndexer.NormalizePath(rawDumpPath);
 
-            string currentContent = _indexer.GetFileContent(currentFilePath);
+            string currentContent = _documentStore.Get(uri) ?? _indexer.GetFileContent(currentFilePath);
             if (string.IsNullOrEmpty(currentContent) || GscCompiledScriptDetector.IsCompiledText(currentContent)) return new LocationContainer();
 
             var currentFileLines = currentContent.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);

--- a/GSCLSP.Server/Handlers/GscRenameHandler.cs
+++ b/GSCLSP.Server/Handlers/GscRenameHandler.cs
@@ -1,4 +1,5 @@
 using GSCLSP.Core.Indexing;
+using GSCLSP.Core.Models;
 using GSCLSP.Lexer;
 using Microsoft.Extensions.Configuration;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -78,7 +79,7 @@ public class GscRenameHandler(GscIndexer indexer, GscDocumentStore documentStore
     {
         var currentFilePath = uri.GetFileSystemPath();
         var content = _documentStore.Get(uri) ?? _indexer.GetFileContent(currentFilePath);
-        if (string.IsNullOrEmpty(content)) return null;
+        if (string.IsNullOrEmpty(content) || GscCompiledScriptDetector.IsCompiledText(content)) return null;
 
         var lines = content.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
         if (position.Line >= lines.Length) return null;

--- a/GSCLSP.slnx
+++ b/GSCLSP.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Project Path="GSCLSP.Benchmark/GSCLSP.Benchmark.csproj" />
   <Project Path="GSCLSP.Core/GSCLSP.Core.csproj" />
+  <Project Path="GSCLSP.Core.Tests/GSCLSP.Core.Tests.csproj" />
   <Project Path="GSCLSP.Lexer/GSCLSP.Lexer.csproj" />
   <Project Path="GSCLSP.Mcp/GSCLSP.Mcp.csproj" />
   <Project Path="GSCLSP.Server/GSCLSP.Server.csproj" />


### PR DESCRIPTION
addresses/fixes #64 unofficially

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compiled GSC scripts are now detected automatically.
  * Language features, including completion, navigation, hover, formatting, diagnostics and refactoring, are disabled for compiled scripts.
  * The editor displays a warning when compiled script features are unavailable.
  * Compiled scripts are excluded from workspace and level indexing.

* **Tests**
  * Added comprehensive coverage for compiled script detection across text and file inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->