### PR TITLE
parse script doc comment blocks & start snippets

### DIFF
--- a/GSCLSP.Core/Formatting/GscBraceRewriter.cs
+++ b/GSCLSP.Core/Formatting/GscBraceRewriter.cs
@@ -1,10 +1,11 @@
+using GSCLSP.Core.Models;
 using static GSCLSP.Core.Models.RegexPatterns;
 
 namespace GSCLSP.Core.Formatting;
 
 internal static class GscBraceRewriter
 {
-    public static List<string> ToAllman(List<string> lines, bool seedInBlock = false)
+    public static List<string> ToAllman(List<string> lines, BlockCommentKind seedInBlock = BlockCommentKind.None)
     {
         var res = new List<string>(lines.Count);
         var inBlock = seedInBlock;
@@ -60,11 +61,11 @@ internal static class GscBraceRewriter
         string Indent,
         string Code,
         string Comment,
-        bool EndsInBlock,
+        BlockCommentKind EndsInBlock,
         bool Transformable
     );
 
-    private static CodeCommentSplit SplitCodeComment(string line, bool inBlock)
+    private static CodeCommentSplit SplitCodeComment(string line, BlockCommentKind inBlock)
     {
         var n = line.Length;
         var i = 0;
@@ -79,9 +80,10 @@ internal static class GscBraceRewriter
             var c = line[i];
             var c2 = i + 1 < n ? line[i + 1] : '\0';
 
-            if (blk)
+            if (blk != BlockCommentKind.None)
             {
-                if (c == '*' && c2 == '/') { blk = false; i += 2; continue; }
+                var closer = blk == BlockCommentKind.Star ? '*' : '@';
+                if (c == closer && c2 == '/') { blk = BlockCommentKind.None; i += 2; continue; }
                 i++;
                 continue;
             }
@@ -95,7 +97,13 @@ internal static class GscBraceRewriter
             }
 
             if (c == '/' && c2 == '/') { commentAt = i; break; }
-            if (c == '/' && c2 == '*') { hasInlineBlock = true; blk = true; i += 2; continue; }
+            if (c == '/' && (c2 == '*' || c2 == '@'))
+            {
+                hasInlineBlock = true;
+                blk = c2 == '*' ? BlockCommentKind.Star : BlockCommentKind.At;
+                i += 2;
+                continue;
+            }
             if (c == '"' || c == '\'') { str = true; sc = c; i++; continue; }
             i++;
         }
@@ -105,7 +113,7 @@ internal static class GscBraceRewriter
         var codeRaw = commentAt >= 0 ? line[..commentAt] : line;
         var code = codeRaw.Trim();
         var comment = commentAt >= 0 ? line[commentAt..] : "";
-        var transformable = !inBlock && !hasInlineBlock && code.Length > 0;
+        var transformable = inBlock == BlockCommentKind.None && !hasInlineBlock && code.Length > 0;
         return new CodeCommentSplit(indent, code, comment, blk, transformable);
     }
 }

--- a/GSCLSP.Core/Formatting/GscFormatterCleanup.cs
+++ b/GSCLSP.Core/Formatting/GscFormatterCleanup.cs
@@ -46,7 +46,7 @@ internal static class GscFormatterCleanup
         var lastCode = -1;
         var inStr = false;
         var sc = '\0';
-        var inBlk = false;
+        var blkCloser = '\0';
         var i = 0;
 
         while (i < n)
@@ -54,9 +54,9 @@ internal static class GscFormatterCleanup
             var ch = line[i];
             var ch2 = i + 1 < n ? line[i + 1] : '\0';
 
-            if (inBlk)
+            if (blkCloser != '\0')
             {
-                if (ch == '*' && ch2 == '/') { inBlk = false; i += 2; continue; }
+                if (ch == blkCloser && ch2 == '/') { blkCloser = '\0'; i += 2; continue; }
                 i++; continue;
             }
             if (inStr)
@@ -66,7 +66,7 @@ internal static class GscFormatterCleanup
                 i++; continue;
             }
             if (ch == '/' && ch2 == '/') break;
-            if (ch == '/' && ch2 == '*') { inBlk = true; i += 2; continue; }
+            if (ch == '/' && (ch2 == '*' || ch2 == '@')) { blkCloser = ch2; i += 2; continue; }
             if (ch == '"' || ch == '\'') { inStr = true; sc = ch; i++; continue; }
             if (ch is not ' ' and not '\t') lastCode = i;
             i++;

--- a/GSCLSP.Core/Formatting/GscIndenter.cs
+++ b/GSCLSP.Core/Formatting/GscIndenter.cs
@@ -1,9 +1,11 @@
+using GSCLSP.Core.Models;
+
 namespace GSCLSP.Core.Formatting;
 
 internal sealed class IndentState
 {
     public List<IndentFrame> Stack { get; } = [];
-    public bool InBlock { get; set; }
+    public BlockCommentKind InBlock { get; set; }
     public bool PendingSwitchBrace { get; set; }
     public int ParenCarry { get; set; }
     public bool PrevContinuesExpr { get; set; }
@@ -50,7 +52,7 @@ internal static class GscIndenter
     public static string IndentLine(IndentState state, string line, string indentUnit)
     {
         var info = LineAnalyzer.Analyze(line, state.InBlock, state.PendingSwitchBrace);
-        var startedInBlock = state.InBlock;
+        var startedInBlock = state.InBlock != BlockCommentKind.None;
         state.InBlock = info.EndsInBlockComment;
         state.PendingSwitchBrace = info.EndsExpectingSwitchBrace;
 

--- a/GSCLSP.Core/Formatting/GscRespacer.cs
+++ b/GSCLSP.Core/Formatting/GscRespacer.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using GSCLSP.Core.Models;
 using GSCLSP.Lexer;
 
 namespace GSCLSP.Core.Formatting;
@@ -17,7 +18,7 @@ internal static class GscRespacer
         "waittill", "waittillmatch", "waittillframeend", "endon", "notify"
     };
 
-    public static List<string> Respace(List<string> rawLines, bool seedInBlock = false)
+    public static List<string> Respace(List<string> rawLines, BlockCommentKind seedInBlock = BlockCommentKind.None)
     {
         var res = new List<string>(rawLines.Count);
         var inBlock = seedInBlock;
@@ -25,7 +26,7 @@ internal static class GscRespacer
         foreach (var rawLine in rawLines)
         {
             var info = LineAnalyzer.Analyze(rawLine, inBlock, false);
-            var startedInBlock = inBlock;
+            var startedInBlock = inBlock != BlockCommentKind.None;
             inBlock = info.EndsInBlockComment;
 
             if (info.IsBlank) { res.Add(""); continue; }

--- a/GSCLSP.Core/Formatting/LineAnalysis.cs
+++ b/GSCLSP.Core/Formatting/LineAnalysis.cs
@@ -1,3 +1,5 @@
+using GSCLSP.Core.Models;
+
 namespace GSCLSP.Core.Formatting;
 
 internal readonly record struct BraceEvent(bool Open, bool IsSwitch);
@@ -11,7 +13,7 @@ internal readonly record struct LineAnalysis(
     int CommentAt,
     bool StartsWithOpenBrace,
     bool IsBracelessHeader,
-    bool EndsInBlockComment,
+    BlockCommentKind EndsInBlockComment,
     bool EndsExpectingSwitchBrace,
     int LeadingClosers,
     string FirstWord,
@@ -27,7 +29,7 @@ internal static class LineAnalyzer
         "if", "for", "while", "foreach", "else", "do"
     };
 
-    public static LineAnalysis Analyze(string line, bool inBlockComment, bool pendingSwitchBrace)
+    public static LineAnalysis Analyze(string line, BlockCommentKind inBlockComment, bool pendingSwitchBrace)
     {
         var n = line.Length;
         var i = 0;
@@ -56,11 +58,12 @@ internal static class LineAnalyzer
             var c = line[i];
             var c2 = i + 1 < n ? line[i + 1] : '\0';
 
-            if (inBlock)
+            if (inBlock != BlockCommentKind.None)
             {
-                if (c == '*' && c2 == '/')
+                var closer = inBlock == BlockCommentKind.Star ? '*' : '@';
+                if (c == closer && c2 == '/')
                 {
-                    inBlock = false;
+                    inBlock = BlockCommentKind.None;
                     i += 2;
                     continue;
                 }
@@ -91,11 +94,11 @@ internal static class LineAnalyzer
                 break;
             }
 
-            if (c == '/' && c2 == '*')
+            if (c == '/' && (c2 == '*' || c2 == '@'))
             {
                 if (firstSig < 0) { firstSig = i; firstSigChar = c; }
                 hasInlineBlockComment = true;
-                inBlock = true;
+                inBlock = c2 == '*' ? BlockCommentKind.Star : BlockCommentKind.At;
                 i += 2;
                 continue;
             }
@@ -206,9 +209,10 @@ internal static class LineAnalyzer
         }
 
         var trimmed = line.Trim();
-        var isBlank = firstSig < 0 && !inBlockComment;
-        var hasCodeAfterBlock = inBlockComment && codeStarted;
-        var isCommentOnly = !codeStarted && !isBlank && !inBlockComment;
+        var startedInBlock = inBlockComment != BlockCommentKind.None;
+        var isBlank = firstSig < 0 && !startedInBlock;
+        var hasCodeAfterBlock = startedInBlock && codeStarted;
+        var isCommentOnly = !codeStarted && !isBlank && !startedInBlock;
         var hasOpenBrace = braces.Exists(b => b.Open);
         var isBracelessHeader =
             codeStarted &&

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -190,7 +190,7 @@ public partial class GscIndexer(ILogger logger)
     private void ParseFile(string path)
     {
         var fileMap = new GscFileMap { FilePath = path };
-        var lines = File.ReadAllLines(path);
+        var lines = ReadLinesWithoutDocComments(path);
 
         foreach (var levelField in ScanLevelFields(lines, path))
             AddDumpLevelField(levelField);
@@ -355,6 +355,26 @@ public partial class GscIndexer(ILogger logger)
         }
 
         return line;
+    }
+
+    private static string[] ReadLinesWithoutDocComments(string path)
+    {
+        var raw = File.ReadAllText(path);
+
+        if (raw.Contains("/@", StringComparison.Ordinal))
+        {
+            raw = DocCommentRegex().Replace(raw, m => string.Create(m.Length, m.Value, static (span, source) =>
+            {
+                for (int i = 0; i < source.Length; i++)
+                    span[i] = source[i] is '\n' or '\r' ? source[i] : ' ';
+            }));
+        }
+
+        var lines = raw.Split('\n');
+        for (int i = 0; i < lines.Length; i++)
+            lines[i] = lines[i].TrimEnd('\r');
+
+        return lines;
     }
 
     private static string CleanGscParams(string raw)
@@ -752,6 +772,19 @@ public partial class GscIndexer(ILogger logger)
                 }
 
                 if (!hasBrace) continue;
+
+                var docBlock = GscDocCommentParser.TryRenderBlockEndingAt(lines, i - 1);
+                if (docBlock != null)
+                {
+                    return new GscSymbol(
+                        Name: fnName,
+                        FilePath: filePath,
+                        LineNumber: i + 1,
+                        Parameters: paramsText,
+                        Type: SymbolType.Function,
+                        Documentation: docBlock
+                    );
+                }
 
                 // Collect documentation comments immediately above definition
                 List<string>? commentLines = null;

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -190,7 +190,7 @@ public partial class GscIndexer(ILogger logger)
     private void ParseFile(string path)
     {
         var fileMap = new GscFileMap { FilePath = path };
-        var lines = ReadLinesWithoutDocComments(path);
+        var lines = ReadLinesWithoutDocComments(path, out var rawLines);
 
         foreach (var levelField in ScanLevelFields(lines, path))
             AddDumpLevelField(levelField);
@@ -238,13 +238,17 @@ public partial class GscIndexer(ILogger logger)
             var isPrivate = nameGroup.Index > 0 &&
                 HasModifierWord(line.AsSpan(0, nameGroup.Index), "private");
 
+            var docBlock = GscDocCommentParser.TryRenderBlockEndingAt(rawLines, lineIndex - 1);
+
             var symbol = new GscSymbol(
                 name,
                 path,
                 lineNum,
                 cleanParams,
                 SymbolType.Function,
-                IsPrivate: isPrivate
+                Documentation: docBlock ?? "",
+                IsPrivate: isPrivate,
+                DocumentationRendered: docBlock != null
             );
             fileMap.LocalSymbols.Add(symbol);
             _symbols.Add(symbol);
@@ -357,20 +361,26 @@ public partial class GscIndexer(ILogger logger)
         return line;
     }
 
-    private static string[] ReadLinesWithoutDocComments(string path)
+    private static string[] ReadLinesWithoutDocComments(string path, out string[] rawLines)
     {
         var raw = File.ReadAllText(path);
+        rawLines = SplitLines(raw);
 
-        if (raw.Contains("/@", StringComparison.Ordinal))
+        if (!raw.Contains("/@", StringComparison.Ordinal))
+            return rawLines;
+
+        var stripped = DocCommentRegex().Replace(raw, m => string.Create(m.Length, m.Value, static (span, source) =>
         {
-            raw = DocCommentRegex().Replace(raw, m => string.Create(m.Length, m.Value, static (span, source) =>
-            {
-                for (int i = 0; i < source.Length; i++)
-                    span[i] = source[i] is '\n' or '\r' ? source[i] : ' ';
-            }));
-        }
+            for (int i = 0; i < source.Length; i++)
+                span[i] = source[i] is '\n' or '\r' ? source[i] : ' ';
+        }));
 
-        var lines = raw.Split('\n');
+        return SplitLines(stripped);
+    }
+
+    private static string[] SplitLines(string text)
+    {
+        var lines = text.Split('\n');
         for (int i = 0; i < lines.Length; i++)
             lines[i] = lines[i].TrimEnd('\r');
 
@@ -658,7 +668,7 @@ public partial class GscIndexer(ILogger logger)
                 return null;
 
             // Read all lines once. We need random access to scan backwards for comments.
-            var lines = File.ReadAllLines(filePath);
+            var lines = ReadLinesWithoutDocComments(filePath, out var rawLines);
             if (lines.Length == 0) return null;
 
             var fnName = functionName ?? string.Empty;
@@ -773,7 +783,7 @@ public partial class GscIndexer(ILogger logger)
 
                 if (!hasBrace) continue;
 
-                var docBlock = GscDocCommentParser.TryRenderBlockEndingAt(lines, i - 1);
+                var docBlock = GscDocCommentParser.TryRenderBlockEndingAt(rawLines, i - 1);
                 if (docBlock != null)
                 {
                     return new GscSymbol(
@@ -782,7 +792,8 @@ public partial class GscIndexer(ILogger logger)
                         LineNumber: i + 1,
                         Parameters: paramsText,
                         Type: SymbolType.Function,
-                        Documentation: docBlock
+                        Documentation: docBlock,
+                        DocumentationRendered: true
                     );
                 }
 

--- a/GSCLSP.Core/Models/BlockCommentKind.cs
+++ b/GSCLSP.Core/Models/BlockCommentKind.cs
@@ -1,0 +1,8 @@
+namespace GSCLSP.Core.Models;
+
+public enum BlockCommentKind
+{
+    None,
+    Star,
+    At
+}

--- a/GSCLSP.Core/Models/GscSymbol.cs
+++ b/GSCLSP.Core/Models/GscSymbol.cs
@@ -12,5 +12,6 @@ public record GscSymbol(
     int? MinArgs = null,
     int? MaxArgs = null,
     bool IsVariadic = false,
-    bool IsPrivate = false
+    bool IsPrivate = false,
+    bool DocumentationRendered = false
 );

--- a/GSCLSP.Core/Models/RegexPatterns.cs
+++ b/GSCLSP.Core/Models/RegexPatterns.cs
@@ -41,6 +41,9 @@ public partial class RegexPatterns
     [GeneratedRegex(@"/\*.*?\*/", RegexOptions.Singleline)]
     public static partial Regex MultilineCommentRegex();
 
+    [GeneratedRegex(@"/@.*?@/", RegexOptions.Singleline)]
+    public static partial Regex DocCommentRegex();
+
     [GeneratedRegex(@"\s+")]
     public static partial Regex WhiteSpaceTabRegex();
 

--- a/GSCLSP.Core/Parsing/GscAnimtreeResolver.cs
+++ b/GSCLSP.Core/Parsing/GscAnimtreeResolver.cs
@@ -33,7 +33,7 @@ public static class GscAnimtreeResolver
     /// </summary>
     public static IEnumerable<AnimtreeUsage> FindUsages(string[] lines)
     {
-        bool inBlockComment = false;
+        var inBlockComment = BlockCommentKind.None;
 
         for (int i = 0; i < lines.Length; i++)
         {
@@ -43,23 +43,24 @@ public static class GscAnimtreeResolver
         }
     }
 
-    private static string StripComments(string line, ref bool inBlockComment)
+    private static string StripComments(string line, ref BlockCommentKind inBlockComment)
     {
         var chars = line.ToCharArray();
         int i = 0;
 
         while (i < chars.Length)
         {
-            if (inBlockComment)
+            if (inBlockComment != BlockCommentKind.None)
             {
-                int close = line.IndexOf("*/", i, StringComparison.Ordinal);
+                var closer = inBlockComment == BlockCommentKind.Star ? "*/" : "@/";
+                int close = line.IndexOf(closer, i, StringComparison.Ordinal);
                 if (close < 0)
                 {
                     for (int j = i; j < chars.Length; j++) chars[j] = ' ';
                     break;
                 }
                 for (int j = i; j < close + 2; j++) chars[j] = ' ';
-                inBlockComment = false;
+                inBlockComment = BlockCommentKind.None;
                 i = close + 2;
                 continue;
             }
@@ -70,9 +71,9 @@ public static class GscAnimtreeResolver
                 break;
             }
 
-            if (i + 1 < chars.Length && chars[i] == '/' && chars[i + 1] == '*')
+            if (i + 1 < chars.Length && chars[i] == '/' && (chars[i + 1] == '*' || chars[i + 1] == '@'))
             {
-                inBlockComment = true;
+                inBlockComment = chars[i + 1] == '*' ? BlockCommentKind.Star : BlockCommentKind.At;
                 continue;
             }
 

--- a/GSCLSP.Core/Parsing/GscDocCommentParser.cs
+++ b/GSCLSP.Core/Parsing/GscDocCommentParser.cs
@@ -1,0 +1,149 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace GSCLSP.Core.Parsing;
+
+public static partial class GscDocCommentParser
+{
+    private const string BlockStart = "/@";
+    private const string BlockEnd = "@/";
+    private const string DescriptionTag = "DESCRIPTION";
+    private const string UsageTag = "USAGE";
+
+    [GeneratedRegex(@"^\[(?<tag>[A-Z][A-Z0-9_]*)\]\s*:\s*(?<rest>.*)$")]
+    private static partial Regex TagRegex();
+
+    [GeneratedRegex(@"<[^<>\s]+>|\[[^\[\]\s]+\]")]
+    private static partial Regex PlaceholderRegex();
+
+    public static bool EndsDocBlock(string line) => line.TrimEnd().EndsWith(BlockEnd, StringComparison.Ordinal);
+
+    public static string? TryRenderBlockEndingAt(IReadOnlyList<string> lines, int endLineIndex)
+    {
+        if (endLineIndex < 0 || endLineIndex >= lines.Count || !EndsDocBlock(lines[endLineIndex]))
+            return null;
+
+        for (int start = endLineIndex; start >= 0; start--)
+        {
+            if (!lines[start].TrimStart().StartsWith(BlockStart, StringComparison.Ordinal))
+                continue;
+
+            var block = new List<string>(endLineIndex - start + 1);
+            for (int i = start; i <= endLineIndex; i++)
+                block.Add(lines[i]);
+
+            var rendered = Render(block);
+            return string.IsNullOrEmpty(rendered) ? null : rendered;
+        }
+
+        return null;
+    }
+
+    public static string Render(IEnumerable<string> rawLines)
+    {
+        var entries = Parse(rawLines);
+        if (entries.Count == 0)
+            return string.Empty;
+
+        var sections = new List<string>();
+
+        foreach (var (tag, value) in entries)
+        {
+            if (tag == DescriptionTag)
+                sections.Add(string.Join("  \n", value.Select(EscapePlaceholders)));
+        }
+
+        foreach (var (tag, value) in entries)
+        {
+            if (tag == UsageTag)
+                sections.Add($"**Usage:**\n```gsc\n{string.Join("\n", value)}\n```");
+        }
+
+        foreach (var (tag, value) in entries)
+        {
+            if (tag is DescriptionTag or UsageTag)
+                continue;
+
+            sections.Add($"**{TitleFor(tag)}:** {string.Join(" ", value.Select(EscapePlaceholders))}");
+        }
+
+        return string.Join("\n\n", sections);
+    }
+
+    private static List<(string Tag, List<string> Value)> Parse(IEnumerable<string> rawLines)
+    {
+        var entries = new List<(string, List<string>)>();
+
+        string? currentTag = null;
+        List<string>? currentValue = null;
+
+        void Flush()
+        {
+            if (currentTag == null || currentValue == null)
+                return;
+
+            if (currentValue.Count > 0)
+                entries.Add((currentTag, currentValue));
+
+            currentTag = null;
+            currentValue = null;
+        }
+
+        foreach (var rawLine in rawLines)
+        {
+            var line = rawLine.Trim();
+
+            if (line.StartsWith(BlockStart, StringComparison.Ordinal))
+                line = line[BlockStart.Length..].Trim();
+
+            if (line.EndsWith(BlockEnd, StringComparison.Ordinal))
+            {
+                line = line[..^BlockEnd.Length].Trim();
+                if (line.Length == 0)
+                {
+                    Flush();
+                    break;
+                }
+            }
+
+            var match = TagRegex().Match(line);
+            if (match.Success)
+            {
+                Flush();
+                currentTag = match.Groups["tag"].Value;
+                currentValue = [];
+                line = match.Groups["rest"].Value.Trim();
+            }
+            else if (currentValue == null)
+            {
+                continue;
+            }
+
+            bool terminated = line.EndsWith(';');
+            if (terminated)
+                line = line[..^1].TrimEnd();
+
+            if (line.Length > 0)
+                currentValue!.Add(line);
+
+            if (terminated)
+                Flush();
+        }
+
+        Flush();
+        return entries;
+    }
+
+    private static string EscapePlaceholders(string value) =>
+        PlaceholderRegex().Replace(value, m => $"`{m.Value}`");
+
+    private static string TitleFor(string tag)
+    {
+        var sb = new StringBuilder(tag.Length);
+        foreach (var c in tag)
+            sb.Append(c == '_' ? ' ' : char.ToLowerInvariant(c));
+
+        sb[0] = char.ToUpperInvariant(sb[0]);
+        return sb.ToString();
+    }
+}

--- a/GSCLSP.Core/Parsing/GscDocCommentParser.cs
+++ b/GSCLSP.Core/Parsing/GscDocCommentParser.cs
@@ -25,6 +25,9 @@ public static partial class GscDocCommentParser
 
         for (int start = endLineIndex; start >= 0; start--)
         {
+            if (start != endLineIndex && EndsDocBlock(lines[start]))
+                return null;
+
             if (!lines[start].TrimStart().StartsWith(BlockStart, StringComparison.Ordinal))
                 continue;
 

--- a/GSCLSP.Extension/language-configuration.json
+++ b/GSCLSP.Extension/language-configuration.json
@@ -14,7 +14,8 @@
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"", "notIn": ["string"] },
-    { "open": "/*", "close": " */", "notIn": ["string"] }
+    { "open": "/*", "close": " */", "notIn": ["string"] },
+    { "open": "/@", "close": " @/", "notIn": ["string"] }
   ],
   "surroundingPairs": [
     ["{", "}"],
@@ -35,6 +36,12 @@
       "action": { "indent": "indent" }
     }
   ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*(/@|/\\*|/#)",
+      "end": "^\\s*(@/|\\*/|#/)"
+    }
+  },
   "indentationRules": {
     "increaseIndentPattern": "^.*\\{[^}]*$",
     "decreaseIndentPattern": "^\\s*\\}.*$"

--- a/GSCLSP.Extension/package.json
+++ b/GSCLSP.Extension/package.json
@@ -93,6 +93,12 @@
         "scopeName": "source.gsc",
         "path": "./syntaxes/gsc.tmLanguage.json"
       }
+    ],
+    "snippets": [
+      {
+        "language": "gsc",
+        "path": "./snippets/gsc.json"
+      }
     ]
   },
   "icon": "logo.png",

--- a/GSCLSP.Extension/snippets/gsc.json
+++ b/GSCLSP.Extension/snippets/gsc.json
@@ -1,0 +1,16 @@
+{
+  "GSC doc comment block": {
+    "prefix": "gscdoc",
+    "description": "gsc-tool script doc comment block",
+    "body": [
+      "/@",
+      "\t[DESCRIPTION]: ${1:description};",
+      "\t[CALL_TYPE]: ${2|function,method|};",
+      "\t[USAGE]: ${3:name( <arg> )};",
+      "\t[PARAMS]: ${4:<type>};",
+      "\t[PARAMS_NOTES]: ${5:notes};",
+      "\t[RETURNS]: ${6:return value};",
+      "@/"
+    ]
+  }
+}

--- a/GSCLSP.Extension/syntaxes/gsc.tmLanguage.json
+++ b/GSCLSP.Extension/syntaxes/gsc.tmLanguage.json
@@ -89,6 +89,25 @@
     "comments": {
       "patterns": [
         {
+          "begin": "/@",
+          "end": "@/",
+          "name": "comment.block.documentation.gsc",
+          "patterns": [
+            {
+              "match": "\\[([A-Z_]+)\\]:",
+              "captures": {
+                "1": {
+                  "name": "storage.type.class.gscdoc"
+                }
+              }
+            },
+            {
+              "match": "<[A-Za-z_]\\w*>",
+              "name": "variable.other.gscdoc"
+            }
+          ]
+        },
+        {
           "begin": "/\\*",
           "end": "\\*/",
           "name": "comment.block.gsc"

--- a/GSCLSP.Lexer/GscLexer.cs
+++ b/GSCLSP.Lexer/GscLexer.cs
@@ -55,9 +55,9 @@ public sealed class GscLexer
                 continue;
             }
 
-            if (current == '/' && Peek(1) == '*')
+            if (current == '/' && (Peek(1) == '*' || Peek(1) == '@'))
             {
-                ReadBlockComment();
+                ReadBlockComment(Peek(1));
                 AddToken(TokenKind.Comment, start, line, column);
                 continue;
             }
@@ -152,7 +152,7 @@ public sealed class GscLexer
         }
     }
 
-    private void ReadBlockComment()
+    private void ReadBlockComment(char terminator)
     {
         var start = _position;
         var line = _line;
@@ -163,7 +163,7 @@ public sealed class GscLexer
 
         while (!IsAtEnd)
         {
-            if (Current == '*' && Peek(1) == '/')
+            if (Current == terminator && Peek(1) == '/')
             {
                 Advance();
                 Advance();

--- a/GSCLSP.Server/Handlers/GscHandlerCommon.cs
+++ b/GSCLSP.Server/Handlers/GscHandlerCommon.cs
@@ -96,38 +96,48 @@ internal static class GscHandlerCommon
             ?? indexer.ResolveLevelField(fieldName);
     }
 
-    public static List<(int Start, int End)> GetCodeRanges(string line, ref bool inBlockComment)
+    public static List<(int Start, int End)> GetCodeRanges(string line, ref BlockCommentKind inBlockComment)
     {
         var ranges = new List<(int Start, int End)>();
         int i = 0;
 
         while (i < line.Length)
         {
-            if (inBlockComment)
+            if (inBlockComment != BlockCommentKind.None)
             {
-                int close = line.IndexOf("*/", i, StringComparison.Ordinal);
+                var closer = inBlockComment == BlockCommentKind.Star ? "*/" : "@/";
+                int close = line.IndexOf(closer, i, StringComparison.Ordinal);
                 if (close < 0) return ranges;
-                inBlockComment = false;
+                inBlockComment = BlockCommentKind.None;
                 i = close + 2;
             }
             else
             {
                 int lineComment = line.IndexOf("//", i, StringComparison.Ordinal);
-                int blockComment = line.IndexOf("/*", i, StringComparison.Ordinal);
+                int starComment = line.IndexOf("/*", i, StringComparison.Ordinal);
+                int atComment = line.IndexOf("/@", i, StringComparison.Ordinal);
                 int stringLiteral = IndexOfStringLiteral(line, i);
 
                 int next = -1;
                 int handlerType = 0; // 0=none, 1=lineComment, 2=blockComment, 3=string
+                var openedKind = BlockCommentKind.None;
 
                 if (lineComment >= 0 && (next < 0 || lineComment < next))
                 {
                     next = lineComment;
                     handlerType = 1;
                 }
-                if (blockComment >= 0 && (next < 0 || blockComment < next))
+                if (starComment >= 0 && (next < 0 || starComment < next))
                 {
-                    next = blockComment;
+                    next = starComment;
                     handlerType = 2;
+                    openedKind = BlockCommentKind.Star;
+                }
+                if (atComment >= 0 && (next < 0 || atComment < next))
+                {
+                    next = atComment;
+                    handlerType = 2;
+                    openedKind = BlockCommentKind.At;
                 }
                 if (stringLiteral >= 0 && (next < 0 || stringLiteral < next))
                 {
@@ -149,7 +159,7 @@ internal static class GscHandlerCommon
                 }
                 else if (handlerType == 2) // block comment
                 {
-                    inBlockComment = true;
+                    inBlockComment = openedKind;
                     i = next + 2;
                 }
                 else if (handlerType == 3) // string literal

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -174,7 +174,9 @@ public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore docume
 
         if (!string.IsNullOrEmpty(symbol.Documentation))
         {
-            var doc = DocRegex().Replace(symbol.Documentation, "**$1:**");
+            var doc = symbol.Documentation.Contains("**", StringComparison.Ordinal)
+                ? symbol.Documentation
+                : DocRegex().Replace(symbol.Documentation, "**$1:**");
             contentValue += $"{doc}\n\n";
         }
 
@@ -345,6 +347,10 @@ public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore docume
     {
         if (lineIndex <= 0 || string.IsNullOrWhiteSpace(lines[lineIndex - 1].Trim()))
             return null;
+
+        var docBlock = GscDocCommentParser.TryRenderBlockEndingAt(lines, lineIndex - 1);
+        if (docBlock != null)
+            return docBlock;
 
         List<string> commentLines = [];
         bool inBlockComment = false;

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -174,7 +174,7 @@ public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore docume
 
         if (!string.IsNullOrEmpty(symbol.Documentation))
         {
-            var doc = symbol.Documentation.Contains("**", StringComparison.Ordinal)
+            var doc = symbol.DocumentationRendered
                 ? symbol.Documentation
                 : DocRegex().Replace(symbol.Documentation, "**$1:**");
             contentValue += $"{doc}\n\n";


### PR DESCRIPTION
closes #65 

<img width="1141" height="455" alt="image" src="https://github.com/user-attachments/assets/8ae1e2f4-cae1-4d56-b13d-d2dc6f1adcef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for structured documentation comment blocks, including rendered descriptions, usage examples, parameters and return details.
  * Added editor snippets, syntax highlighting, folding and auto-closing support for documentation comments.
  * Improved comment handling across formatting, indexing, parsing, hover information and code analysis.

* **Bug Fixes**
  * Correctly preserves and processes both standard and documentation-style block comments during formatting and code navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->