### PR TITLE
add diagnostic warning for duplicate variable names

### DIFF
--- a/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
+++ b/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
@@ -140,6 +140,7 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
             return diagnostics;
 
         var emitted = new HashSet<(int Line, int Column)>();
+        var tokenIndicesByLine = BuildTokenIndicesByLine(tokens);
 
         foreach (var function in GetFunctionDefinitions(lines))
         {
@@ -156,7 +157,7 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
                     continue;
 
                 AddVariableShadowsNamespaceOccurrences(
-                    diagnostics, tokens, muteConfig, excludedMask, emitted,
+                    diagnostics, tokens, tokenIndicesByLine, muteConfig, excludedMask, emitted,
                     declaration.Name, namespaceName, function.DefinitionLine, bodyEnd);
             }
         }
@@ -164,9 +165,31 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
         return diagnostics;
     }
 
+    private static Dictionary<int, List<int>> BuildTokenIndicesByLine(IReadOnlyList<Token> tokens)
+    {
+        var result = new Dictionary<int, List<int>>();
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            if (tokens[i].Kind is not TokenKind.Identifier and not TokenKind.Keyword)
+                continue;
+
+            if (!result.TryGetValue(tokens[i].Line, out var indices))
+            {
+                indices = [];
+                result[tokens[i].Line] = indices;
+            }
+
+            indices.Add(i);
+        }
+
+        return result;
+    }
+
     private static void AddVariableShadowsNamespaceOccurrences(
         List<Diagnostic> diagnostics,
         IReadOnlyList<Token> tokens,
+        Dictionary<int, List<int>> tokenIndicesByLine,
         MuteConfig muteConfig,
         bool[] excludedMask,
         HashSet<(int Line, int Column)> emitted,
@@ -177,41 +200,41 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
     {
         var message = $"Variable '{variableName}' should be named differently: it conflicts with the namespace '{namespaceName}' used by this file.";
 
-        for (int i = 0; i < tokens.Count; i++)
+        for (int line = startLine; line <= endLine; line++)
         {
-            var token = tokens[i];
-            if (token.Kind is not TokenKind.Identifier and not TokenKind.Keyword)
+            if (line < excludedMask.Length && excludedMask[line])
                 continue;
 
-            if (token.Line < startLine || token.Line > endLine)
+            if (!tokenIndicesByLine.TryGetValue(line, out var indices))
                 continue;
 
-            if (!token.Text.Equals(variableName, StringComparison.OrdinalIgnoreCase))
+            if (IsMuted(muteConfig, VariableShadowsNamespaceMuteKey, line))
                 continue;
 
-            if (token.Line < excludedMask.Length && excludedMask[token.Line])
-                continue;
-
-            if (GscVariableTokenFilter.IsNamespaceOrMemberUsage(tokens, i))
-                continue;
-
-            if (IsMuted(muteConfig, VariableShadowsNamespaceMuteKey, token.Line))
-                continue;
-
-            if (!emitted.Add((token.Line, token.Column)))
-                continue;
-
-            diagnostics.Add(new Diagnostic
+            foreach (var i in indices)
             {
-                Severity = DiagnosticSeverity.Warning,
-                Source = "gsclsp",
-                Code = VariableShadowsNamespaceWarningCode,
-                Data = variableName,
-                Message = message,
-                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-                    new Position(token.Line, token.Column),
-                    new Position(token.Line, token.Column + token.Length))
-            });
+                var token = tokens[i];
+                if (!token.Text.Equals(variableName, StringComparison.Ordinal))
+                    continue;
+
+                if (GscVariableTokenFilter.IsNamespaceOrMemberUsage(tokens, i))
+                    continue;
+
+                if (!emitted.Add((token.Line, token.Column)))
+                    continue;
+
+                diagnostics.Add(new Diagnostic
+                {
+                    Severity = DiagnosticSeverity.Warning,
+                    Source = "gsclsp",
+                    Code = VariableShadowsNamespaceWarningCode,
+                    Data = variableName,
+                    Message = message,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                        new Position(token.Line, token.Column),
+                        new Position(token.Line, token.Column + token.Length))
+                });
+            }
         }
     }
 
@@ -247,14 +270,20 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
     private static List<VariableDeclaration> GetDeclaredVariables(string[] lines, FunctionDefinition function, int bodyEnd, bool[] excludedMask)
     {
         var result = new List<VariableDeclaration>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
 
-        var headerMatch = FunctionMultiLineRegex().Match(lines[function.DefinitionLine]);
+        var headerEnd = Math.Min(Math.Max(function.BraceLine, function.DefinitionLine), lines.Length - 1);
+        var header = string.Join('\n', lines[function.DefinitionLine..(headerEnd + 1)]);
+
+        var headerMatch = FunctionMultiLineRegex().Match(header);
         if (headerMatch.Success)
         {
             var paramsGroup = headerMatch.Groups["params"];
-            foreach (var (name, column) in EnumerateParameterDeclarations(paramsGroup.Value, paramsGroup.Index))
-                TryAddDeclaration(result, seen, name, function.DefinitionLine, column);
+            foreach (var (name, offset) in EnumerateParameterDeclarations(paramsGroup.Value, paramsGroup.Index))
+            {
+                var (line, column) = TranslateHeaderOffset(lines, function.DefinitionLine, offset);
+                TryAddDeclaration(result, seen, name, line, column);
+            }
         }
 
         for (int lineIndex = function.BraceLine; lineIndex <= bodyEnd && lineIndex < lines.Length; lineIndex++)
@@ -280,6 +309,19 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
         }
 
         return result;
+    }
+
+    private static (int Line, int Column) TranslateHeaderOffset(string[] lines, int headerStartLine, int offset)
+    {
+        var line = headerStartLine;
+
+        while (line < lines.Length && offset > lines[line].Length)
+        {
+            offset -= lines[line].Length + 1;
+            line++;
+        }
+
+        return (line, offset);
     }
 
     private static void TryAddDeclaration(List<VariableDeclaration> result, HashSet<string> seen, string name, int line, int column)

--- a/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
+++ b/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
@@ -118,12 +118,16 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
         diagnostics.AddRange(CollectMissingAnimtreeErrors(lines, excludedMask));
 
         if (_indexer.IsTreyarchGsc)
-            diagnostics.AddRange(CollectVariableShadowsNamespaceWarnings(lines, muteConfig, excludedMask));
+            diagnostics.AddRange(CollectVariableShadowsNamespaceWarnings(lines, lexed.Tokens, muteConfig, excludedMask));
 
         return diagnostics;
     }
 
-    private List<Diagnostic> CollectVariableShadowsNamespaceWarnings(string[] lines, MuteConfig muteConfig, bool[] excludedMask)
+    private List<Diagnostic> CollectVariableShadowsNamespaceWarnings(
+        string[] lines,
+        IReadOnlyList<Token> tokens,
+        MuteConfig muteConfig,
+        bool[] excludedMask)
     {
         var diagnostics = new List<Diagnostic>();
 
@@ -134,6 +138,8 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
         var referencedNamespaces = GetQualifiedNamespaceReferences(lines, excludedMask, usedNamespaces.Keys);
         if (referencedNamespaces.Count == 0)
             return diagnostics;
+
+        var emitted = new HashSet<(int Line, int Column)>();
 
         foreach (var function in GetFunctionDefinitions(lines))
         {
@@ -149,24 +155,64 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
                 if (!referencedNamespaces.TryGetValue(declaration.Name, out var namespaceName))
                     continue;
 
-                if (IsMuted(muteConfig, VariableShadowsNamespaceMuteKey, declaration.Line))
-                    continue;
-
-                diagnostics.Add(new Diagnostic
-                {
-                    Severity = DiagnosticSeverity.Warning,
-                    Source = "gsclsp",
-                    Code = VariableShadowsNamespaceWarningCode,
-                    Data = declaration.Name,
-                    Message = $"Variable '{declaration.Name}' should be named differently: it conflicts with the namespace '{namespaceName}' used by this file.",
-                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-                        new Position(declaration.Line, declaration.Column),
-                        new Position(declaration.Line, declaration.Column + declaration.Name.Length))
-                });
+                AddVariableShadowsNamespaceOccurrences(
+                    diagnostics, tokens, muteConfig, excludedMask, emitted,
+                    declaration.Name, namespaceName, function.DefinitionLine, bodyEnd);
             }
         }
 
         return diagnostics;
+    }
+
+    private static void AddVariableShadowsNamespaceOccurrences(
+        List<Diagnostic> diagnostics,
+        IReadOnlyList<Token> tokens,
+        MuteConfig muteConfig,
+        bool[] excludedMask,
+        HashSet<(int Line, int Column)> emitted,
+        string variableName,
+        string namespaceName,
+        int startLine,
+        int endLine)
+    {
+        var message = $"Variable '{variableName}' should be named differently: it conflicts with the namespace '{namespaceName}' used by this file.";
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            var token = tokens[i];
+            if (token.Kind is not TokenKind.Identifier and not TokenKind.Keyword)
+                continue;
+
+            if (token.Line < startLine || token.Line > endLine)
+                continue;
+
+            if (!token.Text.Equals(variableName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (token.Line < excludedMask.Length && excludedMask[token.Line])
+                continue;
+
+            if (GscVariableTokenFilter.IsNamespaceOrMemberUsage(tokens, i))
+                continue;
+
+            if (IsMuted(muteConfig, VariableShadowsNamespaceMuteKey, token.Line))
+                continue;
+
+            if (!emitted.Add((token.Line, token.Column)))
+                continue;
+
+            diagnostics.Add(new Diagnostic
+            {
+                Severity = DiagnosticSeverity.Warning,
+                Source = "gsclsp",
+                Code = VariableShadowsNamespaceWarningCode,
+                Data = variableName,
+                Message = message,
+                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                    new Position(token.Line, token.Column),
+                    new Position(token.Line, token.Column + token.Length))
+            });
+        }
     }
 
     private static HashSet<string> GetQualifiedNamespaceReferences(string[] lines, bool[] excludedMask, IEnumerable<string> candidates)

--- a/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
+++ b/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
@@ -17,11 +17,15 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
     public const string InvalidBuiltinArgCountDiagnosticCode = "gsclsp.invalidBuiltinArgCount";
     public const string EarlyReturnWarningCode = "gsclsp.earlyReturn";
     public const string MissingAnimtreeDiagnosticCode = "gsclsp.missingAnimtree";
+    public const string VariableShadowsNamespaceWarningCode = "gsclsp.variableShadowsNamespace";
 
     private const string RecursiveWarningMuteKey = "recursive-function";
     private const string MissingSemicolonMuteKey = "missing-semicolon";
     private const string BuiltinArgCountMuteKey = "builtin-arg-count";
     private const string EarlyReturnMuteKey = "early-return";
+    private const string VariableShadowsNamespaceMuteKey = "variable-shadows-namespace";
+
+    private static readonly string[] ForeachVariableGroups = ["first", "second"];
     private static readonly bool ResolutionTraceEnabled =
         string.Equals(Environment.GetEnvironmentVariable("GSCLSP_TRACE_RESOLUTION"), "1", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(Environment.GetEnvironmentVariable("GSCLSP_TRACE_RESOLUTION"), "true", StringComparison.OrdinalIgnoreCase);
@@ -113,7 +117,158 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
         diagnostics.AddRange(CollectEarlyReturnWarnings(lines, lexed.Tokens, muteConfig, excludedMask));
         diagnostics.AddRange(CollectMissingAnimtreeErrors(lines, excludedMask));
 
+        if (_indexer.IsTreyarchGsc)
+            diagnostics.AddRange(CollectVariableShadowsNamespaceWarnings(lines, muteConfig, excludedMask));
+
         return diagnostics;
+    }
+
+    private List<Diagnostic> CollectVariableShadowsNamespaceWarnings(string[] lines, MuteConfig muteConfig, bool[] excludedMask)
+    {
+        var diagnostics = new List<Diagnostic>();
+
+        var usedNamespaces = _indexer.GetUsedNamespaces(lines);
+        if (usedNamespaces.Count == 0)
+            return diagnostics;
+
+        var referencedNamespaces = GetQualifiedNamespaceReferences(lines, excludedMask, usedNamespaces.Keys);
+        if (referencedNamespaces.Count == 0)
+            return diagnostics;
+
+        foreach (var function in GetFunctionDefinitions(lines))
+        {
+            if (function.DefinitionLine < excludedMask.Length && excludedMask[function.DefinitionLine])
+                continue;
+
+            var bodyEnd = FindFunctionBodyEndLine(lines, function.BraceLine);
+            if (bodyEnd < function.BraceLine)
+                continue;
+
+            foreach (var declaration in GetDeclaredVariables(lines, function, bodyEnd, excludedMask))
+            {
+                if (!referencedNamespaces.TryGetValue(declaration.Name, out var namespaceName))
+                    continue;
+
+                if (IsMuted(muteConfig, VariableShadowsNamespaceMuteKey, declaration.Line))
+                    continue;
+
+                diagnostics.Add(new Diagnostic
+                {
+                    Severity = DiagnosticSeverity.Warning,
+                    Source = "gsclsp",
+                    Code = VariableShadowsNamespaceWarningCode,
+                    Data = declaration.Name,
+                    Message = $"Variable '{declaration.Name}' should be named differently: it conflicts with the namespace '{namespaceName}' used by this file.",
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                        new Position(declaration.Line, declaration.Column),
+                        new Position(declaration.Line, declaration.Column + declaration.Name.Length))
+                });
+            }
+        }
+
+        return diagnostics;
+    }
+
+    private static HashSet<string> GetQualifiedNamespaceReferences(string[] lines, bool[] excludedMask, IEnumerable<string> candidates)
+    {
+        var pool = new HashSet<string>(candidates, StringComparer.OrdinalIgnoreCase);
+        var referenced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        for (int lineIndex = 0; lineIndex < lines.Length && referenced.Count < pool.Count; lineIndex++)
+        {
+            if (lineIndex < excludedMask.Length && excludedMask[lineIndex])
+                continue;
+
+            var line = StripTrailingLineComment(lines[lineIndex]);
+
+            int index = line.IndexOf("::", StringComparison.Ordinal);
+            while (index >= 0)
+            {
+                int start = index;
+                while (start > 0 && (char.IsLetterOrDigit(line[start - 1]) || line[start - 1] == '_'))
+                    start--;
+
+                if (start < index && pool.TryGetValue(line[start..index], out var canonical))
+                    referenced.Add(canonical);
+
+                index = line.IndexOf("::", index + 2, StringComparison.Ordinal);
+            }
+        }
+
+        return referenced;
+    }
+
+    private static List<VariableDeclaration> GetDeclaredVariables(string[] lines, FunctionDefinition function, int bodyEnd, bool[] excludedMask)
+    {
+        var result = new List<VariableDeclaration>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var headerMatch = FunctionMultiLineRegex().Match(lines[function.DefinitionLine]);
+        if (headerMatch.Success)
+        {
+            var paramsGroup = headerMatch.Groups["params"];
+            foreach (var (name, column) in EnumerateParameterDeclarations(paramsGroup.Value, paramsGroup.Index))
+                TryAddDeclaration(result, seen, name, function.DefinitionLine, column);
+        }
+
+        for (int lineIndex = function.BraceLine; lineIndex <= bodyEnd && lineIndex < lines.Length; lineIndex++)
+        {
+            if (lineIndex < excludedMask.Length && excludedMask[lineIndex])
+                continue;
+
+            var line = StripTrailingLineComment(lines[lineIndex]);
+
+            var assignment = LocalVarAssignmentRegex().Match(line);
+            if (assignment.Success)
+                TryAddDeclaration(result, seen, assignment.Groups[1].Value, lineIndex, assignment.Groups[1].Index);
+
+            foreach (Match iteration in ForeachVariablesRegex().Matches(line))
+            {
+                foreach (var groupName in ForeachVariableGroups)
+                {
+                    var group = iteration.Groups[groupName];
+                    if (group.Success)
+                        TryAddDeclaration(result, seen, group.Value, lineIndex, group.Index);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static void TryAddDeclaration(List<VariableDeclaration> result, HashSet<string> seen, string name, int line, int column)
+    {
+        if (string.IsNullOrEmpty(name) || GscLanguageKeywords.LocalVariableReservedWords.Contains(name))
+            return;
+
+        if (seen.Add(name))
+            result.Add(new VariableDeclaration(name, line, column));
+    }
+
+    private static IEnumerable<(string Name, int Column)> EnumerateParameterDeclarations(string parameters, int parametersColumn)
+    {
+        int segmentStart = 0;
+
+        for (int i = 0; i <= parameters.Length; i++)
+        {
+            if (i < parameters.Length && parameters[i] != ',')
+                continue;
+
+            var segment = parameters[segmentStart..i];
+
+            int nameStart = 0;
+            while (nameStart < segment.Length && (char.IsWhiteSpace(segment[nameStart]) || segment[nameStart] is '&' or '*'))
+                nameStart++;
+
+            int nameEnd = nameStart;
+            while (nameEnd < segment.Length && (char.IsLetterOrDigit(segment[nameEnd]) || segment[nameEnd] == '_'))
+                nameEnd++;
+
+            if (nameEnd > nameStart && (char.IsLetter(segment[nameStart]) || segment[nameStart] == '_'))
+                yield return (segment[nameStart..nameEnd], parametersColumn + segmentStart + nameStart);
+
+            segmentStart = i + 1;
+        }
     }
 
     private static List<Diagnostic> CollectMissingAnimtreeErrors(string[] lines, bool[] excludedMask)
@@ -874,6 +1029,12 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
             if (normalized is "early-return" or "early-returns" or "unreachable")
             {
                 keys.Add(EarlyReturnMuteKey);
+                continue;
+            }
+
+            if (normalized is "variable-shadows-namespace" or "namespace-shadow" or "shadowed-namespace")
+            {
+                keys.Add(VariableShadowsNamespaceMuteKey);
             }
         }
 
@@ -1117,4 +1278,5 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
     private sealed record IncludedFileScope(string Path, HashSet<string> Functions, string? Namespace = null);
     private sealed record FunctionDefinition(string Name, int DefinitionLine, int NameColumn, int BraceLine);
     private sealed record MuteConfig(HashSet<string> TopOfFileMutes, Dictionary<int, HashSet<string>> LineMutes);
+    private sealed record VariableDeclaration(string Name, int Line, int Column);
 }

--- a/GSCLSP.Core/Models/RegexPatterns.cs
+++ b/GSCLSP.Core/Models/RegexPatterns.cs
@@ -56,7 +56,7 @@ public partial class RegexPatterns
     [GeneratedRegex(@"^([A-Za-z_]\w*)\s*=\s*(.+?)\s*;")]
     public static partial Regex GlobalVarAssignmentRegex();
 
-    [GeneratedRegex(@"\bforeach\s*\(\s*(?<first>[A-Za-z_]\w*)\s*(?:,\s*(?<second>[A-Za-z_]\w*)\s*)?\bin\b")]
+    [GeneratedRegex(@"\bforeach\s*\(\s*(?<first>[A-Za-z_]\w*)\s*(?:,\s*(?<second>[A-Za-z_]\w*)\s*)?\bin\b", RegexOptions.IgnoreCase)]
     public static partial Regex ForeachVariablesRegex();
 
     [GeneratedRegex(@"(?:(?<path>[a-zA-Z_]\w*(?:\\[a-zA-Z_]\w*)*)::|(?<global>::))?(?<name>[a-zA-Z_]\w*)\s*\(")]

--- a/GSCLSP.Core/Models/RegexPatterns.cs
+++ b/GSCLSP.Core/Models/RegexPatterns.cs
@@ -56,6 +56,9 @@ public partial class RegexPatterns
     [GeneratedRegex(@"^([A-Za-z_]\w*)\s*=\s*(.+?)\s*;")]
     public static partial Regex GlobalVarAssignmentRegex();
 
+    [GeneratedRegex(@"\bforeach\s*\(\s*(?<first>[A-Za-z_]\w*)\s*(?:,\s*(?<second>[A-Za-z_]\w*)\s*)?\bin\b")]
+    public static partial Regex ForeachVariablesRegex();
+
     [GeneratedRegex(@"(?:(?<path>[a-zA-Z_]\w*(?:\\[a-zA-Z_]\w*)*)::|(?<global>::))?(?<name>[a-zA-Z_]\w*)\s*\(")]
     public static partial Regex CallSiteRegex();
 

--- a/GSCLSP.Core/Parsing/GscFunctionBodyLocator.cs
+++ b/GSCLSP.Core/Parsing/GscFunctionBodyLocator.cs
@@ -1,0 +1,56 @@
+using GSCLSP.Core.Models;
+
+namespace GSCLSP.Core.Parsing;
+
+public static class GscFunctionBodyLocator
+{
+    public static (int BraceStartLine, int BraceEndLine)? FindEnclosingFunctionBodyRange(string[] lines, int cursorLine)
+    {
+        int funcDefLine = -1;
+        for (int i = Math.Min(cursorLine, lines.Length - 1); i >= 0; i--)
+        {
+            var line = lines[i];
+            if (line.Length == 0 || char.IsWhiteSpace(line[0]))
+                continue;
+            if (line.TrimStart().StartsWith("//", StringComparison.Ordinal))
+                continue;
+            if (line.Contains(';'))
+                continue;
+
+            var match = RegexPatterns.FunctionMultiLineRegex().Match(line);
+            if (match.Success && match.Index == 0)
+            {
+                funcDefLine = i;
+                break;
+            }
+        }
+
+        if (funcDefLine < 0)
+            return null;
+
+        int braceStart = -1;
+        for (int i = funcDefLine; i < lines.Length; i++)
+        {
+            if (lines[i].Contains('{')) { braceStart = i; break; }
+        }
+        if (braceStart < 0)
+            return null;
+
+        int depth = 0;
+        int braceEnd = lines.Length - 1;
+        for (int i = braceStart; i < lines.Length; i++)
+        {
+            foreach (char c in lines[i])
+            {
+                if (c == '{') depth++;
+                else if (c == '}') depth--;
+            }
+            if (depth == 0) { braceEnd = i; break; }
+        }
+
+        if (cursorLine < funcDefLine || cursorLine > braceEnd)
+            return null;
+
+        return (funcDefLine, braceEnd);
+    }
+}

--- a/GSCLSP.Core/Parsing/GscVariableTokenFilter.cs
+++ b/GSCLSP.Core/Parsing/GscVariableTokenFilter.cs
@@ -1,0 +1,27 @@
+using GSCLSP.Lexer;
+
+namespace GSCLSP.Core.Parsing;
+
+public static class GscVariableTokenFilter
+{
+    public static bool IsNamespaceOrMemberUsage(IReadOnlyList<Token> tokens, int index)
+    {
+        if (FindSignificantToken(tokens, index, 1)?.Kind is TokenKind.DoubleColon)
+            return true;
+
+        return FindSignificantToken(tokens, index, -1)?.Kind is TokenKind.DoubleColon or TokenKind.Dot;
+    }
+
+    public static Token? FindSignificantToken(IReadOnlyList<Token> tokens, int index, int step)
+    {
+        for (int i = index + step; i >= 0 && i < tokens.Count; i += step)
+        {
+            if (tokens[i].Kind is TokenKind.Whitespace or TokenKind.Comment)
+                continue;
+
+            return tokens[i];
+        }
+
+        return null;
+    }
+}

--- a/GSCLSP.Core/Parsing/GscVariableTokenFilter.cs
+++ b/GSCLSP.Core/Parsing/GscVariableTokenFilter.cs
@@ -14,6 +14,8 @@ public static class GscVariableTokenFilter
 
     public static Token? FindSignificantToken(IReadOnlyList<Token> tokens, int index, int step)
     {
+        ArgumentOutOfRangeException.ThrowIfZero(step);
+
         for (int i = index + step; i >= 0 && i < tokens.Count; i += step)
         {
             if (tokens[i].Kind is TokenKind.Whitespace or TokenKind.Comment)

--- a/GSCLSP.Extension/README.md
+++ b/GSCLSP.Extension/README.md
@@ -52,10 +52,12 @@ When you hover your mouse cursor over any sort of function, macro, variable, or 
 - `gsclsp.invalidBuiltinArgCount`: Built-in argument count warning
 - `gsclsp.earlyReturn`: Early return cutting off code warning
 - `gsclsp.missingAnimtree`: Sanity check #animtree for valid #using_animtree
+- `gsclsp.variableShadowsNamespace`: Variable named after a namespace the file uses (Treyarch games only)
 
 ### Code Actions
 
 - Quick fix to insert `#include ...` for unresolved functions
+- Quick fix to rename a variable that shadows a used namespace to `_<name>`
 
 ## Project Setup
 

--- a/GSCLSP.Extension/README.md
+++ b/GSCLSP.Extension/README.md
@@ -57,7 +57,7 @@ When you hover your mouse cursor over any sort of function, macro, variable, or 
 ### Code Actions
 
 - Quick fix to insert `#include ...` for unresolved functions
-- Quick fix to rename a variable that shadows a used namespace to `_<name>`
+- Quick fix to rename a variable that shadows a used namespace to `_<name>` (a numeric suffix is added if that name is already taken)
 
 ## Project Setup
 
@@ -138,6 +138,7 @@ Supported format:
 - `// gsclsp-disable: recursive-function`
 - `// gsclsp-disable: missing-semicolon`
 - `// gsclsp-disable: builtin-arg-count`
+- `// gsclsp-disable: variable-shadows-namespace`
 - `// gsclsp-disable: recursive, semicolon, builtin-args`
 - `// gsclsp-disable: all`
 
@@ -146,6 +147,7 @@ Aliases supported:
 - `recursive` -> `recursive-function`
 - `semicolon` -> `missing-semicolon`
 - `builtin-args` or `arity` -> `builtin-arg-count`
+- `namespace-shadow` or `shadowed-namespace` -> `variable-shadows-namespace`
 
 ## Command
 

--- a/GSCLSP.Mcp/Resources/gsc-primer.md
+++ b/GSCLSP.Mcp/Resources/gsc-primer.md
@@ -227,6 +227,11 @@ util::wait_network_frame();                                     // Treyarch: `na
 Backslash form is a file path from the script root (`maps\mp\_utility` =
 `maps/mp/_utility.gsc`). Namespace form uses the `#namespace` declared in the target file.
 
+**`jup` only — reserved-keyword namespaces.** If the target file's `#namespace` is a reserved
+keyword (e.g. `class`), `class::func()` collides with the compiler's keyword handling; use the
+path form instead — `scripts\mp\class::func()`. Namespace form stays the default everywhere
+else; only fall back to the path form when the namespace actually breaks compiling.
+
 ### Directives
 
 ```gsc

--- a/GSCLSP.Mcp/Resources/gsc-primer.md
+++ b/GSCLSP.Mcp/Resources/gsc-primer.md
@@ -227,11 +227,6 @@ util::wait_network_frame();                                     // Treyarch: `na
 Backslash form is a file path from the script root (`maps\mp\_utility` =
 `maps/mp/_utility.gsc`). Namespace form uses the `#namespace` declared in the target file.
 
-**`jup` only — reserved-keyword namespaces.** If the target file's `#namespace` is a reserved
-keyword (e.g. `class`), `class::func()` collides with the compiler's keyword handling; use the
-path form instead — `scripts\mp\class::func()`. Namespace form stays the default everywhere
-else; only fall back to the path form when the namespace actually breaks compiling.
-
 ### Directives
 
 ```gsc
@@ -469,6 +464,41 @@ Caveats:
 - Black Ops 3 source code explorer: https://bo3explorer.zeroy.com/
 - Ghosts developer GSC dump: https://github.com/mjkzy/iw6-gsc-dump
 - MWR (H1) reverse-engineered dump, ~98% named — useful for s1/s2/h1/h2: https://github.com/mjkzy/h1-gsc-dump
+
+## JUP-only rules (IMPORTANT FOR JUP)
+
+**reserved-keyword namespaces.** If the target file's `#namespace` is a reserved
+keyword (e.g. `class`), `class::func()` collides with the atian-cod-tools compiler's keyword handling; use the
+script path form instead from legacy GSC like so:  `scripts\mp\class::func()`. Namespace form stays the default everywhere else; only fall back to the path form when the namespace actually breaks compiling, or you think it may warrant a use case over the namespace being used.
+
+**issue with entity thread function calls.** The atian-cod-tools compiler miscompiles a
+threaded call that has BOTH an entity prefix AND a direct function name. The script compiles
+but the call misbehaves at runtime. Broken shape — `<entity> thread <name>(args)`:
+
+```gsc
+self thread monitor(slot);                      // BROKEN
+player thread util::do_thing(a, b);             // BROKEN — namespace form too
+self thread scripts\mp\class::setclass(x);      // BROKEN — path form too
+```
+
+Rewrite **every such call** as a function-reference invoke. It **is preferred** when there is a thread keyword being used in function calls. To do it properly, you take `&name`, call it with `[[ ]]` wrapping it:
+
+```gsc
+self thread [[ &monitor ]](slot);                    // local function
+player thread [[ &util::do_thing ]](a, b);           // namespace-qualified
+self thread [[ &scripts\mp\class::setclass ]](x);    // path-qualified
+```
+
+NOT affected — leave these forms alone:
+
+```gsc
+foo();                        // no entity prefix
+self foo();                   // no thread
+self thread [[ ref ]]();      // already a reference invoke ([[ variable ]] or [[ &name ]])
+```
+
+Detection rule: the token before `thread` is an entity (`self`, `level`, or a variable) AND
+the token after `thread` is a function name, not `[[`. On `jup`, ALWAYS apply the rewrite. Other 3arc GSC games do **not** need this.
 
 ## Comment Rules
 

--- a/GSCLSP.Server/Handlers/GscCodeActionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCodeActionHandler.cs
@@ -1,4 +1,7 @@
+using GSCLSP.Core.Diagnostics;
+using GSCLSP.Core.Models;
 using GSCLSP.Core.Parsing;
+using GSCLSP.Lexer;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
@@ -35,7 +38,141 @@ public class GscCodeActionHandler(GscDocumentStore documentStore, GscDiagnostics
             }
         }
 
+        var renamedVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var diagnostic in request.Context.Diagnostics.Where(IsVariableShadowsNamespaceDiagnostic))
+        {
+            var name = GetDiagnosticIdentifier(diagnostic, text);
+            if (string.IsNullOrWhiteSpace(name) || !renamedVariables.Add(name))
+                continue;
+
+            var renameAction = CreateRenameShadowingVariableAction(uri, text, diagnostic, name);
+            if (renameAction is not null)
+                actions.Add(new CommandOrCodeAction(renameAction));
+        }
+
         return new CommandOrCodeActionContainer(actions);
+    }
+
+    private static bool IsVariableShadowsNamespaceDiagnostic(Diagnostic diagnostic)
+    {
+        return string.Equals(diagnostic.Source, "gsclsp", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(diagnostic.Code?.ToString(), GscDiagnosticsAnalyzer.VariableShadowsNamespaceWarningCode, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CodeAction? CreateRenameShadowingVariableAction(DocumentUri uri, string text, Diagnostic diagnostic, string name)
+    {
+        var lines = text.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+        if (diagnostic.Range.Start.Line >= lines.Length)
+            return null;
+
+        var bodyRange = FindEnclosingFunctionBodyRange(lines, diagnostic.Range.Start.Line);
+        if (bodyRange is null)
+            return null;
+
+        var newName = $"_{name}";
+        var edits = CollectVariableRenameEdits(GscLexingHelper.Lex(text).Tokens, bodyRange.Value, name, newName);
+        if (edits.Count == 0)
+            return null;
+
+        return new CodeAction
+        {
+            Title = $"Rename '{name}' to '{newName}'",
+            Kind = CodeActionKind.QuickFix,
+            IsPreferred = true,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [uri] = edits
+                }
+            }
+        };
+    }
+
+    private static List<TextEdit> CollectVariableRenameEdits(
+        IReadOnlyList<Token> tokens,
+        (int StartLine, int EndLine) bodyRange,
+        string name,
+        string newName)
+    {
+        var edits = new List<TextEdit>();
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            var token = tokens[i];
+            if (token.Kind is not TokenKind.Identifier and not TokenKind.Keyword)
+                continue;
+
+            if (token.Line < bodyRange.StartLine || token.Line > bodyRange.EndLine)
+                continue;
+
+            if (!token.Text.Equals(name, StringComparison.Ordinal))
+                continue;
+
+            if (GscVariableTokenFilter.IsNamespaceOrMemberUsage(tokens, i))
+                continue;
+
+            edits.Add(new TextEdit
+            {
+                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                    new Position(token.Line, token.Column),
+                    new Position(token.Line, token.Column + token.Length)),
+                NewText = newName
+            });
+        }
+
+        return edits;
+    }
+
+    private static (int StartLine, int EndLine)? FindEnclosingFunctionBodyRange(string[] lines, int cursorLine)
+    {
+        int funcDefLine = -1;
+        for (int i = cursorLine; i >= 0; i--)
+        {
+            var line = lines[i];
+            if (line.Length == 0 || char.IsWhiteSpace(line[0]))
+                continue;
+            if (line.TrimStart().StartsWith("//", StringComparison.Ordinal))
+                continue;
+            if (line.Contains(';'))
+                continue;
+
+            var match = RegexPatterns.FunctionMultiLineRegex().Match(line);
+            if (match.Success && match.Index == 0)
+            {
+                funcDefLine = i;
+                break;
+            }
+        }
+
+        if (funcDefLine < 0)
+            return null;
+
+        int braceStart = -1;
+        for (int i = funcDefLine; i < lines.Length; i++)
+        {
+            if (lines[i].Contains('{')) { braceStart = i; break; }
+        }
+        if (braceStart < 0)
+            return null;
+
+        int depth = 0;
+        int braceEnd = lines.Length - 1;
+        for (int i = braceStart; i < lines.Length; i++)
+        {
+            foreach (char c in lines[i])
+            {
+                if (c == '{') depth++;
+                else if (c == '}') depth--;
+            }
+            if (depth == 0) { braceEnd = i; break; }
+        }
+
+        if (cursorLine < funcDefLine || cursorLine > braceEnd)
+            return null;
+
+        return (funcDefLine, braceEnd);
     }
 
     public CodeActionRegistrationOptions GetRegistrationOptions(CodeActionCapability capability, ClientCapabilities clientCapabilities)
@@ -58,7 +195,7 @@ public class GscCodeActionHandler(GscDocumentStore documentStore, GscDiagnostics
 
         foreach (var diagnostic in request.Context.Diagnostics.Where(IsUnresolvedFunctionDiagnostic))
         {
-            var functionName = GetFunctionName(diagnostic, text);
+            var functionName = GetDiagnosticIdentifier(diagnostic, text);
             if (string.IsNullOrWhiteSpace(functionName) || !seen.Add(functionName))
                 continue;
 
@@ -88,7 +225,7 @@ public class GscCodeActionHandler(GscDocumentStore documentStore, GscDiagnostics
         return diagnostic.Message.Contains("not defined in this file or its included files", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string GetFunctionName(Diagnostic diagnostic, string text)
+    private static string GetDiagnosticIdentifier(Diagnostic diagnostic, string text)
     {
         var dataValue = diagnostic.Data?.ToString();
         if (!string.IsNullOrWhiteSpace(dataValue))

--- a/GSCLSP.Server/Handlers/GscCodeActionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCodeActionHandler.cs
@@ -1,4 +1,4 @@
-using GSCLSP.Core.Diagnostics;
+﻿using GSCLSP.Core.Diagnostics;
 using GSCLSP.Core.Models;
 using GSCLSP.Core.Parsing;
 using GSCLSP.Lexer;
@@ -38,7 +38,7 @@ public class GscCodeActionHandler(GscDocumentStore documentStore, GscDiagnostics
             }
         }
 
-        var renamedVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var renamedVariables = new HashSet<string>(StringComparer.Ordinal);
         foreach (var diagnostic in request.Context.Diagnostics.Where(IsVariableShadowsNamespaceDiagnostic))
         {
             var name = GetDiagnosticIdentifier(diagnostic, text);
@@ -65,12 +65,13 @@ public class GscCodeActionHandler(GscDocumentStore documentStore, GscDiagnostics
         if (diagnostic.Range.Start.Line >= lines.Length)
             return null;
 
-        var bodyRange = FindEnclosingFunctionBodyRange(lines, diagnostic.Range.Start.Line);
+        var bodyRange = GscFunctionBodyLocator.FindEnclosingFunctionBodyRange(lines, diagnostic.Range.Start.Line);
         if (bodyRange is null)
             return null;
 
-        var newName = $"_{name}";
-        var edits = CollectVariableRenameEdits(GscLexingHelper.Lex(text).Tokens, bodyRange.Value, name, newName);
+        var tokens = GscLexingHelper.Lex(text).Tokens;
+        var newName = CreateUniqueName(tokens, bodyRange.Value, name);
+        var edits = CollectVariableRenameEdits(tokens, bodyRange.Value, name, newName);
         if (edits.Count == 0)
             return null;
 
@@ -90,9 +91,34 @@ public class GscCodeActionHandler(GscDocumentStore documentStore, GscDiagnostics
         };
     }
 
+    private static string CreateUniqueName(
+        IReadOnlyList<Token> tokens,
+        (int BraceStartLine, int BraceEndLine) bodyRange,
+        string name)
+    {
+        var used = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var token in tokens)
+        {
+            if (token.Kind is not TokenKind.Identifier and not TokenKind.Keyword)
+                continue;
+
+            if (token.Line < bodyRange.BraceStartLine || token.Line > bodyRange.BraceEndLine)
+                continue;
+
+            used.Add(token.Text);
+        }
+
+        var candidate = $"_{name}";
+        for (int suffix = 2; used.Contains(candidate); suffix++)
+            candidate = $"_{name}{suffix}";
+
+        return candidate;
+    }
+
     private static List<TextEdit> CollectVariableRenameEdits(
         IReadOnlyList<Token> tokens,
-        (int StartLine, int EndLine) bodyRange,
+        (int BraceStartLine, int BraceEndLine) bodyRange,
         string name,
         string newName)
     {
@@ -104,7 +130,7 @@ public class GscCodeActionHandler(GscDocumentStore documentStore, GscDiagnostics
             if (token.Kind is not TokenKind.Identifier and not TokenKind.Keyword)
                 continue;
 
-            if (token.Line < bodyRange.StartLine || token.Line > bodyRange.EndLine)
+            if (token.Line < bodyRange.BraceStartLine || token.Line > bodyRange.BraceEndLine)
                 continue;
 
             if (!token.Text.Equals(name, StringComparison.Ordinal))
@@ -123,56 +149,6 @@ public class GscCodeActionHandler(GscDocumentStore documentStore, GscDiagnostics
         }
 
         return edits;
-    }
-
-    private static (int StartLine, int EndLine)? FindEnclosingFunctionBodyRange(string[] lines, int cursorLine)
-    {
-        int funcDefLine = -1;
-        for (int i = cursorLine; i >= 0; i--)
-        {
-            var line = lines[i];
-            if (line.Length == 0 || char.IsWhiteSpace(line[0]))
-                continue;
-            if (line.TrimStart().StartsWith("//", StringComparison.Ordinal))
-                continue;
-            if (line.Contains(';'))
-                continue;
-
-            var match = RegexPatterns.FunctionMultiLineRegex().Match(line);
-            if (match.Success && match.Index == 0)
-            {
-                funcDefLine = i;
-                break;
-            }
-        }
-
-        if (funcDefLine < 0)
-            return null;
-
-        int braceStart = -1;
-        for (int i = funcDefLine; i < lines.Length; i++)
-        {
-            if (lines[i].Contains('{')) { braceStart = i; break; }
-        }
-        if (braceStart < 0)
-            return null;
-
-        int depth = 0;
-        int braceEnd = lines.Length - 1;
-        for (int i = braceStart; i < lines.Length; i++)
-        {
-            foreach (char c in lines[i])
-            {
-                if (c == '{') depth++;
-                else if (c == '}') depth--;
-            }
-            if (depth == 0) { braceEnd = i; break; }
-        }
-
-        if (cursorLine < funcDefLine || cursorLine > braceEnd)
-            return null;
-
-        return (funcDefLine, braceEnd);
     }
 
     public CodeActionRegistrationOptions GetRegistrationOptions(CodeActionCapability capability, ClientCapabilities clientCapabilities)

--- a/GSCLSP.Server/Handlers/GscReferencesHandler.cs
+++ b/GSCLSP.Server/Handlers/GscReferencesHandler.cs
@@ -1,4 +1,5 @@
-﻿using GSCLSP.Core.Indexing;
+using System.Collections.Concurrent;
+using GSCLSP.Core.Indexing;
 using GSCLSP.Core.Models;
 using GSCLSP.Core.Parsing;
 using GSCLSP.Lexer;
@@ -16,6 +17,15 @@ namespace GSCLSP.Server.Handlers
         private readonly GscDocumentStore _documentStore = documentStore;
         private readonly IConfiguration _configuration = configuration;
 
+        private enum ReferenceKind { Function, LocalVariable, MemberField, FileScoped, Macro }
+
+        private sealed record ReferenceTarget(
+            ReferenceKind Kind,
+            string Name,
+            string? DefiningPath,
+            (int StartLine, int EndLine)? FunctionBodyRange,
+            bool WorkspaceWide);
+
         public async Task<LocationContainer?> Handle(ReferenceParams request, CancellationToken cancellationToken)
         {
             var uri = request.TextDocument.Uri;
@@ -28,16 +38,28 @@ namespace GSCLSP.Server.Handlers
             if (string.IsNullOrEmpty(currentContent) || GscCompiledScriptDetector.IsCompiledText(currentContent)) return new LocationContainer();
 
             var currentFileLines = currentContent.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
-            var line = currentFileLines[request.Position.Line];
-            string identifier = GscWordScanner.GetFullIdentifierAt(line, request.Position.Character);
+            if (request.Position.Line >= currentFileLines.Length) return new LocationContainer();
 
-            if (identifier.StartsWith("::")) identifier = identifier[2..];
-            if (string.IsNullOrEmpty(identifier)) return new LocationContainer();
+            var lexed = GscLexingHelper.Lex(currentContent);
+            int cursorIndex = FindIdentifierTokenIndex(lexed.Tokens, request.Position);
+            if (cursorIndex < 0) return new LocationContainer();
+
+            var target = ResolveTarget(lexed.Tokens, cursorIndex, currentFileLines, currentFilePath, normalizedDumpPath);
+            if (target is null) return new LocationContainer();
 
             var locations = new List<Location>();
 
-            // Search current file
-            SearchFileWithLexer(currentFilePath, currentContent, identifier, locations);
+            // Scoped kinds never leave the current document.
+            if (target.Kind is ReferenceKind.LocalVariable or ReferenceKind.MemberField or ReferenceKind.FileScoped)
+            {
+                CollectMatches(currentFilePath, lexed.Tokens, currentFileLines, target, locations, normalizedDumpPath);
+                return new LocationContainer(locations);
+            }
+
+            CollectMatches(currentFilePath, lexed.Tokens, currentFileLines, target, locations, normalizedDumpPath);
+
+            if (target.Kind == ReferenceKind.Macro && !target.WorkspaceWide)
+                return new LocationContainer(locations);
 
             // Search included files
             var includedPaths = await ExtractIncludesAsync(currentFileLines, cancellationToken);
@@ -48,7 +70,7 @@ namespace GSCLSP.Server.Handlers
                     if (File.Exists(includePath))
                     {
                         var includedContent = await File.ReadAllTextAsync(includePath, cancellationToken);
-                        SearchFileWithLexer(includePath, includedContent, identifier, locations);
+                        SearchFile(includePath, includedContent, target, locations, normalizedDumpPath);
                     }
                 }
                 catch { }
@@ -67,27 +89,69 @@ namespace GSCLSP.Server.Handlers
                         string content = _indexer.GetFileContent(file);
                         if (!string.IsNullOrEmpty(content))
                         {
-                            SearchFileWithLexer(file, content, identifier, locations);
+                            SearchFile(file, content, target, locations, normalizedDumpPath);
                         }
                     }
                     catch { }
                 });
             }
 
-            // Search indexed symbols
-            var indexedMatches = _indexer.GetSymbolsByName(identifier);
-            foreach (var symbol in indexedMatches)
+            // Search indexed symbols, but only the ones that are the resolved definition
+            if (target.Kind == ReferenceKind.Function)
             {
-                if (symbol.FilePath == "Engine") continue;
+                foreach (var symbol in _indexer.GetSymbolsByName(target.Name))
+                {
+                    if (symbol.FilePath == "Engine") continue;
 
-                string targetPath = symbol.FilePath;
-                if (!Path.IsPathRooted(targetPath) && !string.IsNullOrEmpty(normalizedDumpPath))
-                    targetPath = Path.Combine(normalizedDumpPath, targetPath);
+                    var symbolPath = ToFullPath(symbol.FilePath, normalizedDumpPath);
+                    if (symbolPath is null) continue;
 
-                AddLocationIfUnique(locations, targetPath, Math.Max(0, symbol.LineNumber - 1), 0, identifier.Length);
+                    if (target.DefiningPath is not null &&
+                        !symbolPath.Equals(target.DefiningPath, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    AddLocationIfUnique(locations, symbolPath, Math.Max(0, symbol.LineNumber - 1), 0, target.Name.Length);
+                }
             }
 
             return new LocationContainer(locations);
+        }
+
+        private ReferenceTarget? ResolveTarget(IReadOnlyList<Token> tokens, int cursorIndex, string[] lines, string currentFilePath, string? dumpPath)
+        {
+            var token = tokens[cursorIndex];
+            var name = token.Text;
+            if (string.IsNullOrEmpty(name)) return null;
+
+            // Cursor sits on the namespace part of 'ns::func' - nothing meaningful to list.
+            if (GscVariableTokenFilter.FindSignificantToken(tokens, cursorIndex, 1)?.Kind is TokenKind.DoubleColon)
+                return null;
+
+            var line = lines[token.Line];
+
+            var fileMacros = GscIndexer.GetFileMacros(currentFilePath);
+            if (fileMacros.Any(m => m.Name.Equals(name, StringComparison.Ordinal)))
+                return new ReferenceTarget(ReferenceKind.Macro, name, null, null, false);
+
+            if (_indexer.ResolveMacro(currentFilePath, name) != null)
+                return new ReferenceTarget(ReferenceKind.Macro, name, null, null, true);
+
+            if (IsFunctionUsage(tokens, cursorIndex))
+            {
+                var qualified = QualifiedNameAt(line, token.Column, name);
+                var symbol = _indexer.ResolveFunction(currentFilePath, qualified).Symbol;
+                var definingPath = ToFullPath(symbol?.FilePath, dumpPath);
+                return new ReferenceTarget(ReferenceKind.Function, name, definingPath, null, true);
+            }
+
+            if (GscVariableTokenFilter.FindSignificantToken(tokens, cursorIndex, -1)?.Kind is TokenKind.Dot)
+                return new ReferenceTarget(ReferenceKind.MemberField, name, null, null, false);
+
+            var bodyRange = FindEnclosingFunctionBodyRange(lines, token.Line);
+            if (bodyRange is not null)
+                return new ReferenceTarget(ReferenceKind.LocalVariable, name, null, bodyRange, false);
+
+            return new ReferenceTarget(ReferenceKind.FileScoped, name, null, null, false);
         }
 
         private async Task<List<string>> ExtractIncludesAsync(string[] fileLines, CancellationToken cancellationToken)
@@ -111,21 +175,204 @@ namespace GSCLSP.Server.Handlers
             return [.. includePaths];
         }
 
-        private static void SearchFileWithLexer(string filePath, string content, string identifier, List<Location> locations)
+        private void SearchFile(string filePath, string content, ReferenceTarget target, List<Location> locations, string? dumpPath)
         {
-            var lexer = new GscLexer();
-            var result = lexer.Lex(content);
+            if (!content.Contains(target.Name, StringComparison.OrdinalIgnoreCase)) return;
 
-            foreach (var token in result.Tokens)
+            var lexed = GscLexingHelper.Lex(content);
+            var lines = content.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+            CollectMatches(filePath, lexed.Tokens, lines, target, locations, dumpPath);
+        }
+
+        private void CollectMatches(string filePath, IReadOnlyList<Token> tokens, string[] lines, ReferenceTarget target, List<Location> locations, string? dumpPath)
+        {
+            var resolutionCache = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+            for (int i = 0; i < tokens.Count; i++)
             {
-                if (token.Kind is not TokenKind.Identifier and not TokenKind.Keyword)
-                    continue;
+                var token = tokens[i];
 
-                if (!token.Text.Equals(identifier, StringComparison.OrdinalIgnoreCase))
+                if (token.Kind is TokenKind.Directive)
+                {
+                    if (target.Kind == ReferenceKind.Macro && MacroDirectiveMatches(token, target.Name, out int defineCol))
+                        AddLocationIfUnique(locations, filePath, token.Line, defineCol, target.Name.Length);
                     continue;
+                }
+
+                if (token.Kind is not TokenKind.Identifier and not TokenKind.Keyword) continue;
+                if (!token.Text.Equals(target.Name, StringComparison.OrdinalIgnoreCase)) continue;
+                if (token.Line >= lines.Length) continue;
+
+                bool isFunctionUsage = IsFunctionUsage(tokens, i);
+
+                switch (target.Kind)
+                {
+                    case ReferenceKind.Function:
+                        if (!isFunctionUsage) continue;
+                        if (!FunctionUsageResolvesToTarget(filePath, lines[token.Line], token, target, dumpPath, resolutionCache)) continue;
+                        break;
+
+                    case ReferenceKind.LocalVariable:
+                        var (start, end) = target.FunctionBodyRange!.Value;
+                        if (token.Line < start || token.Line > end) continue;
+                        if (isFunctionUsage) continue;
+                        if (GscVariableTokenFilter.IsNamespaceOrMemberUsage(tokens, i)) continue;
+                        break;
+
+                    case ReferenceKind.MemberField:
+                        if (GscVariableTokenFilter.FindSignificantToken(tokens, i, -1)?.Kind is not TokenKind.Dot) continue;
+                        break;
+
+                    case ReferenceKind.FileScoped:
+                        if (isFunctionUsage) continue;
+                        if (GscVariableTokenFilter.IsNamespaceOrMemberUsage(tokens, i)) continue;
+                        break;
+
+                    case ReferenceKind.Macro:
+                        break;
+                }
 
                 AddLocationIfUnique(locations, filePath, token.Line, token.Column, token.Length);
             }
+        }
+
+        private bool FunctionUsageResolvesToTarget(string filePath, string line, Token token, ReferenceTarget target, string? dumpPath, Dictionary<string, bool> cache)
+        {
+            // No known definition (engine builtin or unindexed) - call shape is all we can verify.
+            if (target.DefiningPath is null) return true;
+
+            var qualified = QualifiedNameAt(line, token.Column, target.Name);
+
+            lock (cache)
+            {
+                if (cache.TryGetValue(qualified, out var cached)) return cached;
+            }
+
+            var symbol = _indexer.ResolveFunction(filePath, qualified).Symbol;
+            var resolvedPath = ToFullPath(symbol?.FilePath, dumpPath);
+            bool matches = resolvedPath is not null && resolvedPath.Equals(target.DefiningPath, StringComparison.OrdinalIgnoreCase);
+
+            lock (cache)
+            {
+                cache[qualified] = matches;
+            }
+
+            return matches;
+        }
+
+        // Returns 'ns::name' / 'maps\mp\_util::name' when the occurrence is qualified, otherwise the bare name.
+        private static string QualifiedNameAt(string line, int column, string fallback)
+        {
+            var full = GscWordScanner.GetFullIdentifierAt(line, column);
+            if (string.IsNullOrEmpty(full)) return fallback;
+            if (full.StartsWith("::", StringComparison.Ordinal)) full = full[2..];
+            return string.IsNullOrEmpty(full) ? fallback : full;
+        }
+
+        private static bool IsFunctionUsage(IReadOnlyList<Token> tokens, int index)
+        {
+            if (GscVariableTokenFilter.FindSignificantToken(tokens, index, 1)?.Kind is TokenKind.OpenParen)
+                return true;
+
+            // '&func' pointers and 'ns::func' references are function usages even without a call.
+            return GscVariableTokenFilter.FindSignificantToken(tokens, index, -1)?.Kind is TokenKind.Ampersand or TokenKind.DoubleColon;
+        }
+
+        private static bool MacroDirectiveMatches(Token token, string name, out int column)
+        {
+            column = 0;
+            var text = token.Text;
+            if (string.IsNullOrEmpty(text)) return false;
+
+            var trimStart = text.TrimStart();
+            int leadingWs = text.Length - trimStart.Length;
+            if (!trimStart.StartsWith("#define", StringComparison.Ordinal)) return false;
+
+            var afterDefine = trimStart[7..];
+            int nameStart = leadingWs + 7 + (afterDefine.Length - afterDefine.TrimStart().Length);
+            int nameEnd = nameStart;
+            while (nameEnd < text.Length && (char.IsLetterOrDigit(text[nameEnd]) || text[nameEnd] == '_'))
+                nameEnd++;
+
+            if (nameEnd - nameStart != name.Length) return false;
+            if (!text.AsSpan(nameStart, name.Length).Equals(name.AsSpan(), StringComparison.Ordinal)) return false;
+
+            column = token.Column + nameStart;
+            return true;
+        }
+
+        private static int FindIdentifierTokenIndex(IReadOnlyList<Token> tokens, Position position)
+        {
+            int best = -1;
+            for (int i = 0; i < tokens.Count; i++)
+            {
+                var token = tokens[i];
+                if (token.Length == 0 || token.Line != position.Line) continue;
+                if (token.Kind is not TokenKind.Identifier and not TokenKind.Keyword) continue;
+
+                if (position.Character >= token.Column && position.Character < token.Column + token.Length)
+                    return i;
+
+                // cursor parked just past the identifier
+                if (position.Character == token.Column + token.Length) best = i;
+            }
+
+            return best;
+        }
+
+        private static (int StartLine, int EndLine)? FindEnclosingFunctionBodyRange(string[] lines, int cursorLine)
+        {
+            int funcDefLine = -1;
+            for (int i = cursorLine; i >= 0; i--)
+            {
+                var ln = lines[i];
+                if (ln.Length == 0) continue;
+                if (char.IsWhiteSpace(ln[0])) continue;
+                if (ln.TrimStart().StartsWith("//", StringComparison.Ordinal)) continue;
+                if (ln.Contains(';')) continue;
+
+                var match = RegexPatterns.FunctionMultiLineRegex().Match(ln);
+                if (match.Success && match.Index == 0)
+                {
+                    funcDefLine = i;
+                    break;
+                }
+            }
+            if (funcDefLine < 0) return null;
+
+            int braceStart = -1;
+            for (int i = funcDefLine; i < lines.Length; i++)
+            {
+                if (lines[i].Contains('{')) { braceStart = i; break; }
+            }
+            if (braceStart < 0) return null;
+
+            int depth = 0;
+            int braceEnd = lines.Length - 1;
+            for (int i = braceStart; i < lines.Length; i++)
+            {
+                foreach (char c in lines[i])
+                {
+                    if (c == '{') depth++;
+                    else if (c == '}') depth--;
+                }
+                if (depth == 0) { braceEnd = i; break; }
+            }
+
+            if (cursorLine < funcDefLine || cursorLine > braceEnd) return null;
+            return (funcDefLine, braceEnd);
+        }
+
+        private static string? ToFullPath(string? path, string? dumpPath)
+        {
+            if (string.IsNullOrEmpty(path) || path == "Engine") return null;
+
+            var normalized = path.Replace('/', '\\');
+            if (!Path.IsPathRooted(normalized) && !string.IsNullOrEmpty(dumpPath))
+                normalized = Path.Combine(dumpPath, normalized);
+
+            try { return Path.GetFullPath(normalized); }
+            catch { return normalized; }
         }
 
         private static void AddLocationIfUnique(List<Location> locations, string path, int line, int col, int length)

--- a/GSCLSP.Server/Handlers/GscRenameHandler.cs
+++ b/GSCLSP.Server/Handlers/GscRenameHandler.cs
@@ -1,4 +1,4 @@
-using GSCLSP.Core.Indexing;
+﻿using GSCLSP.Core.Indexing;
 using GSCLSP.Core.Models;
 using GSCLSP.Core.Parsing;
 using GSCLSP.Lexer;
@@ -129,7 +129,7 @@ public class GscRenameHandler(GscIndexer indexer, GscDocumentStore documentStore
             return new RenameTarget(RenameKind.Function, name, token.Line, token.Column, token.Column + token.Length, null, MacroScope.LocalFileOnly);
         }
 
-        var funcRange = FindEnclosingFunctionBodyRange(lines, token.Line);
+        var funcRange = GscFunctionBodyLocator.FindEnclosingFunctionBodyRange(lines, token.Line);
         if (funcRange is not null)
         {
             return new RenameTarget(RenameKind.LocalVariable, name, token.Line, token.Column, token.Column + token.Length, funcRange, MacroScope.LocalFileOnly);
@@ -251,49 +251,6 @@ public class GscRenameHandler(GscIndexer indexer, GscDocumentStore documentStore
         }
 
         return next is { Kind: TokenKind.OpenParen };
-    }
-
-    private static (int BraceStartLine, int BraceEndLine)? FindEnclosingFunctionBodyRange(string[] lines, int cursorLine)
-    {
-        int funcDefLine = -1;
-        for (int i = cursorLine; i >= 0; i--)
-        {
-            var ln = lines[i];
-            if (ln.Length == 0) continue;
-            if (char.IsWhiteSpace(ln[0])) continue;
-            if (ln.TrimStart().StartsWith("//", StringComparison.Ordinal)) continue;
-            if (ln.Contains(';')) continue;
-
-            var match = RegexPatterns.FunctionMultiLineRegex().Match(ln);
-            if (match.Success && match.Index == 0)
-            {
-                funcDefLine = i;
-                break;
-            }
-        }
-        if (funcDefLine < 0) return null;
-
-        int braceStart = -1;
-        for (int i = funcDefLine; i < lines.Length; i++)
-        {
-            if (lines[i].Contains('{')) { braceStart = i; break; }
-        }
-        if (braceStart < 0) return null;
-
-        int depth = 0;
-        int braceEnd = lines.Length - 1;
-        for (int i = braceStart; i < lines.Length; i++)
-        {
-            foreach (char c in lines[i])
-            {
-                if (c == '{') depth++;
-                else if (c == '}') depth--;
-            }
-            if (depth == 0) { braceEnd = i; break; }
-        }
-
-        if (cursorLine < funcDefLine || cursorLine > braceEnd) return null;
-        return (funcDefLine, braceEnd);
     }
 
     private static bool IsTopLevelAssignmentTarget(string line, int column, string name)

--- a/GSCLSP.Server/Handlers/GscRenameHandler.cs
+++ b/GSCLSP.Server/Handlers/GscRenameHandler.cs
@@ -1,5 +1,6 @@
 using GSCLSP.Core.Indexing;
 using GSCLSP.Core.Models;
+using GSCLSP.Core.Parsing;
 using GSCLSP.Lexer;
 using Microsoft.Extensions.Configuration;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -116,6 +117,13 @@ public class GscRenameHandler(GscIndexer indexer, GscDocumentStore documentStore
             return new RenameTarget(RenameKind.Macro, name, token.Line, token.Column, token.Column + token.Length, null, MacroScope.Workspace);
         }
 
+        var tokenIndex = IndexOfToken(lexed.Tokens, token);
+        if (tokenIndex >= 0 &&
+            GscVariableTokenFilter.FindSignificantToken(lexed.Tokens, tokenIndex, 1)?.Kind is TokenKind.DoubleColon)
+        {
+            return null;
+        }
+
         if (IsFunctionReference(lexed.Tokens, token))
         {
             return new RenameTarget(RenameKind.Function, name, token.Line, token.Column, token.Column + token.Length, null, MacroScope.LocalFileOnly);
@@ -188,6 +196,18 @@ public class GscRenameHandler(GscIndexer indexer, GscDocumentStore documentStore
         return null;
     }
 
+    private static int IndexOfToken(IReadOnlyList<Token> tokens, Token target)
+    {
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            var token = tokens[i];
+            if (token.Line == target.Line && token.Column == target.Column && token.Length == target.Length)
+                return i;
+        }
+
+        return -1;
+    }
+
     private static bool IsIdentifierChar(char c) => char.IsLetterOrDigit(c) || c == '_';
 
     private static bool TryGetDefineNameSpan(Token token, out int column, out int length, out string name)
@@ -244,7 +264,8 @@ public class GscRenameHandler(GscIndexer indexer, GscDocumentStore documentStore
             if (ln.TrimStart().StartsWith("//", StringComparison.Ordinal)) continue;
             if (ln.Contains(';')) continue;
 
-            if (System.Text.RegularExpressions.Regex.IsMatch(ln, @"^\w[\w:]*\s*\("))
+            var match = RegexPatterns.FunctionMultiLineRegex().Match(ln);
+            if (match.Success && match.Index == 0)
             {
                 funcDefLine = i;
                 break;
@@ -355,11 +376,13 @@ public class GscRenameHandler(GscIndexer indexer, GscDocumentStore documentStore
         var edits = new List<TextEdit>();
         var (start, end) = target.FunctionBodyRange.Value;
 
-        foreach (var token in lexed.Tokens)
+        for (int i = 0; i < lexed.Tokens.Count; i++)
         {
+            var token = lexed.Tokens[i];
             if (token.Kind is not TokenKind.Identifier and not TokenKind.Keyword) continue;
             if (token.Line < start || token.Line > end) continue;
             if (!token.Text.Equals(target.Name, StringComparison.Ordinal)) continue;
+            if (GscVariableTokenFilter.IsNamespaceOrMemberUsage(lexed.Tokens, i)) continue;
 
             edits.Add(new TextEdit
             {


### PR DESCRIPTION
this includes various small fixes too, including:
- fixing the rename provider to work better for function parameters
- variables getting confused for namespaces/file paths that are included, leading to runtime errors and confusion in GSCLSP
- improving GSCLSP MCP primer for a few edge cases.

<img width="1016" height="290" alt="image" src="https://github.com/user-attachments/assets/3f516c49-a6b4-4e31-9f92-f8eb1ba52673" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added diagnostics for variables that shadow namespaces used with `::`.
  - Added a quick fix to rename conflicting variables with an underscore.
  - Improved rename support by preventing edits to namespace and member references.

- **Documentation**
  - Added guidance for handling namespace conflicts in `jup` scripts.
  - Documented the new variable-shadowing diagnostic and its rename action.

- **Bug Fixes**
  - Improved detection of foreach variables and namespace-related usages.
  - Added support for muted and excluded diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->