### PR TITLE
add const, better keyword handling & highlighting

### DIFF
--- a/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
+++ b/GSCLSP.Core/Diagnostics/GscDiagnosticsAnalyzer.cs
@@ -19,6 +19,7 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
     public const string MissingAnimtreeDiagnosticCode = "gsclsp.missingAnimtree";
     public const string VariableShadowsNamespaceWarningCode = "gsclsp.variableShadowsNamespace";
     public const string MisleadingIndentationErrorCode = "gsclsp.misleadingIndentation";
+    public const string ConstReassignmentDiagnosticCode = "gsclsp.constReassignment";
 
     private const string RecursiveWarningMuteKey = "recursive-function";
     private const string MissingSemicolonMuteKey = "missing-semicolon";
@@ -26,6 +27,7 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
     private const string EarlyReturnMuteKey = "early-return";
     private const string VariableShadowsNamespaceMuteKey = "variable-shadows-namespace";
     private const string MisleadingIndentationMuteKey = "misleading-indentation";
+    private const string ConstReassignmentMuteKey = "const-reassignment";
 
     private static readonly string[] ForeachVariableGroups = ["first", "second"];
     private static readonly bool ResolutionTraceEnabled =
@@ -119,6 +121,7 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
         diagnostics.AddRange(CollectEarlyReturnWarnings(lines, lexed.Tokens, muteConfig, excludedMask));
         diagnostics.AddRange(CollectMissingAnimtreeErrors(lines, excludedMask));
         diagnostics.AddRange(CollectMisleadingIndentationErrors(lines, lexed.Tokens, muteConfig, excludedMask));
+        diagnostics.AddRange(CollectConstReassignmentErrors(lines, lexed.Tokens, muteConfig, excludedMask));
 
         if (_indexer.IsTreyarchGsc)
             diagnostics.AddRange(CollectVariableShadowsNamespaceWarnings(lines, lexed.Tokens, muteConfig, excludedMask));
@@ -241,6 +244,171 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
         }
     }
 
+    private List<Diagnostic> CollectConstReassignmentErrors(
+        string[] lines,
+        IReadOnlyList<Token> tokens,
+        MuteConfig muteConfig,
+        bool[] excludedMask)
+    {
+        var diagnostics = new List<Diagnostic>();
+        var tokenIndicesByLine = BuildTokenIndicesByLine(tokens);
+
+        foreach (var function in GetFunctionDefinitions(lines))
+        {
+            if (function.DefinitionLine < excludedMask.Length && excludedMask[function.DefinitionLine])
+                continue;
+
+            var bodyEnd = FindFunctionBodyEndLine(lines, function.BraceLine);
+            if (bodyEnd < function.BraceLine)
+                continue;
+
+            foreach (var declaration in GetDeclaredVariables(lines, function, bodyEnd, excludedMask))
+            {
+                if (!declaration.IsConst)
+                    continue;
+
+                AddConstReassignmentOccurrences(
+                    diagnostics, lines, tokens, tokenIndicesByLine, muteConfig, excludedMask,
+                    declaration.Name, declaration.Line, bodyEnd);
+            }
+        }
+
+        return diagnostics;
+    }
+
+    private static void AddConstReassignmentOccurrences(
+        List<Diagnostic> diagnostics,
+        string[] lines,
+        IReadOnlyList<Token> tokens,
+        Dictionary<int, List<int>> tokenIndicesByLine,
+        MuteConfig muteConfig,
+        bool[] excludedMask,
+        string constName,
+        int declLine,
+        int bodyEnd)
+    {
+        var emitted = new HashSet<(int Line, int Column)>();
+
+        for (int line = declLine + 1; line <= bodyEnd && line < lines.Length; line++)
+        {
+            if (line < excludedMask.Length && excludedMask[line])
+                continue;
+
+            if (IsMuted(muteConfig, ConstReassignmentMuteKey, line))
+                continue;
+
+            var foreachMatch = ForeachVariablesRegex().Match(StripTrailingLineComment(lines[line]));
+            if (foreachMatch.Success)
+            {
+                foreach (var groupName in ForeachVariableGroups)
+                {
+                    var group = foreachMatch.Groups[groupName];
+                    if (group.Success && group.Value.Equals(constName, StringComparison.Ordinal))
+                        AddConstDiagnostic(diagnostics, emitted, constName, declLine, line, group.Index);
+                }
+            }
+
+            if (!tokenIndicesByLine.TryGetValue(line, out var indices))
+                continue;
+
+            foreach (var i in indices)
+            {
+                var token = tokens[i];
+                if (!token.Text.Equals(constName, StringComparison.Ordinal))
+                    continue;
+
+                if (GscVariableTokenFilter.IsNamespaceOrMemberUsage(tokens, i))
+                    continue;
+
+                if (!IsConstReassignmentToken(tokens, i))
+                    continue;
+
+                AddConstDiagnostic(diagnostics, emitted, constName, declLine, token.Line, token.Column);
+            }
+        }
+    }
+
+    private static void AddConstDiagnostic(
+        List<Diagnostic> diagnostics,
+        HashSet<(int Line, int Column)> emitted,
+        string constName,
+        int declLine,
+        int line,
+        int column)
+    {
+        if (!emitted.Add((line, column)))
+            return;
+
+        diagnostics.Add(new Diagnostic
+        {
+            Severity = DiagnosticSeverity.Error,
+            Source = "gsclsp",
+            Code = ConstReassignmentDiagnosticCode,
+            Data = constName,
+            Message = $"Cannot reassign '{constName}': it was declared as const (line {declLine + 1}).",
+            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+                new Position(line, column),
+                new Position(line, column + constName.Length))
+        });
+    }
+
+    private static bool IsConstReassignmentToken(IReadOnlyList<Token> tokens, int index)
+    {
+        int nextIdx = FindSignificantTokenIndex(tokens, index, 1);
+        if (nextIdx >= 0)
+        {
+            var nextKind = tokens[nextIdx].Kind;
+            if (IsAssignmentOperator(nextKind))
+                return true;
+
+            if (nextKind is TokenKind.Pipe or TokenKind.Ampersand or TokenKind.Caret)
+            {
+                int afterIdx = FindSignificantTokenIndex(tokens, nextIdx, 1);
+                if (afterIdx >= 0 && tokens[afterIdx].Kind == TokenKind.Equals)
+                    return true;
+            }
+        }
+
+        int prevIdx = FindSignificantTokenIndex(tokens, index, -1);
+        if (prevIdx >= 0)
+        {
+            var prevKind = tokens[prevIdx].Kind;
+            if (prevKind is TokenKind.PlusPlus or TokenKind.MinusMinus)
+                return true;
+
+            if (prevKind == TokenKind.Keyword &&
+                tokens[prevIdx].Text.Equals("const", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsAssignmentOperator(TokenKind kind) =>
+        kind is TokenKind.Equals
+            or TokenKind.PlusEquals
+            or TokenKind.MinusEquals
+            or TokenKind.StarEquals
+            or TokenKind.SlashEquals
+            or TokenKind.PercentEquals
+            or TokenKind.PlusPlus
+            or TokenKind.MinusMinus;
+
+    private static int FindSignificantTokenIndex(IReadOnlyList<Token> tokens, int index, int step)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(step);
+
+        for (int i = index + step; i >= 0 && i < tokens.Count; i += step)
+        {
+            if (tokens[i].Kind is TokenKind.Whitespace or TokenKind.Comment)
+                continue;
+
+            return i;
+        }
+
+        return -1;
+    }
+
     private static HashSet<string> GetQualifiedNamespaceReferences(string[] lines, bool[] excludedMask, IEnumerable<string> candidates)
     {
         var pool = new HashSet<string>(candidates, StringComparer.OrdinalIgnoreCase);
@@ -300,6 +468,10 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
             if (assignment.Success)
                 TryAddDeclaration(result, seen, assignment.Groups[1].Value, lineIndex, assignment.Groups[1].Index);
 
+            var constAssignment = ConstVarAssignmentRegex().Match(line);
+            if (constAssignment.Success)
+                TryAddDeclaration(result, seen, constAssignment.Groups[1].Value, lineIndex, constAssignment.Groups[1].Index, isConst: true);
+
             foreach (Match iteration in ForeachVariablesRegex().Matches(line))
             {
                 foreach (var groupName in ForeachVariableGroups)
@@ -327,13 +499,13 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
         return (line, offset);
     }
 
-    private static void TryAddDeclaration(List<VariableDeclaration> result, HashSet<string> seen, string name, int line, int column)
+    private static void TryAddDeclaration(List<VariableDeclaration> result, HashSet<string> seen, string name, int line, int column, bool isConst = false)
     {
         if (string.IsNullOrEmpty(name) || GscLanguageKeywords.LocalVariableReservedWords.Contains(name))
             return;
 
         if (seen.Add(name))
-            result.Add(new VariableDeclaration(name, line, column));
+            result.Add(new VariableDeclaration(name, line, column, isConst));
     }
 
     private static IEnumerable<(string Name, int Column)> EnumerateParameterDeclarations(string parameters, int parametersColumn)
@@ -1324,6 +1496,11 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
             {
                 keys.Add(MisleadingIndentationMuteKey);
             }
+
+            if (normalized is "const-reassignment" or "const")
+            {
+                keys.Add(ConstReassignmentMuteKey);
+            }
         }
 
         return keys.Count > 0;
@@ -1566,5 +1743,5 @@ public sealed class GscDiagnosticsAnalyzer(GscIndexer indexer, ILogger logger)
     private sealed record IncludedFileScope(string Path, HashSet<string> Functions, string? Namespace = null);
     private sealed record FunctionDefinition(string Name, int DefinitionLine, int NameColumn, int BraceLine);
     private sealed record MuteConfig(HashSet<string> TopOfFileMutes, Dictionary<int, HashSet<string>> LineMutes);
-    private sealed record VariableDeclaration(string Name, int Line, int Column);
+    private sealed record VariableDeclaration(string Name, int Line, int Column, bool IsConst);
 }

--- a/GSCLSP.Core/Indexing/GscIndexer.Workspace.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.Workspace.cs
@@ -345,8 +345,9 @@ public partial class GscIndexer
                 continue;
 
             var nameGroup = funcMatch.Groups["name"];
-            var isPrivate = nameGroup.Index > 0 &&
-                HasModifierWord(line.AsSpan(0, nameGroup.Index), "private");
+            var prefix = line.AsSpan(0, nameGroup.Index);
+            var isPrivate = nameGroup.Index > 0 && HasModifierWord(prefix, "private");
+            var isAutoExec = nameGroup.Index > 0 && HasModifierWord(prefix, "autoexec");
 
             var symbol = new GscSymbol(
                 funcMatch.Groups["name"].Value,
@@ -354,7 +355,8 @@ public partial class GscIndexer
                 lineNum,
                 CleanGscParams(funcMatch.Groups["params"].Value),
                 SymbolType.Function,
-                IsPrivate: isPrivate
+                IsPrivate: isPrivate,
+                IsAutoExec: isAutoExec
             );
 
             symbols.Add(symbol);

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -251,8 +251,9 @@ public partial class GscIndexer(ILogger logger)
             var rawParams = funcMatch.Groups["params"].Value;
             var cleanParams = CleanGscParams(rawParams);
             var nameGroup = funcMatch.Groups["name"];
-            var isPrivate = nameGroup.Index > 0 &&
-                HasModifierWord(line.AsSpan(0, nameGroup.Index), "private");
+            var prefix = line.AsSpan(0, nameGroup.Index);
+            var isPrivate = nameGroup.Index > 0 && HasModifierWord(prefix, "private");
+            var isAutoExec = nameGroup.Index > 0 && HasModifierWord(prefix, "autoexec");
 
             var docBlock = GscDocCommentParser.TryRenderBlockEndingAt(rawLines, lineIndex - 1);
 
@@ -264,6 +265,7 @@ public partial class GscIndexer(ILogger logger)
                 SymbolType.Function,
                 Documentation: docBlock ?? "",
                 IsPrivate: isPrivate,
+                IsAutoExec: isAutoExec,
                 DocumentationRendered: docBlock != null
             );
             fileMap.LocalSymbols.Add(symbol);
@@ -710,6 +712,7 @@ public partial class GscIndexer(ILogger logger)
                     continue;
 
                 int pos = -1;
+                int prefixLength = 0;
                 string checkLine = codeLine;
 
                 if (!codeLine.StartsWith(fnName, StringComparison.OrdinalIgnoreCase))
@@ -748,6 +751,7 @@ public partial class GscIndexer(ILogger logger)
                     if (!skipLine)
                     {
                         int nameStartInCodeLine = codeLine.Length - checkLine.Length;
+                        prefixLength = nameStartInCodeLine;
                         int nameEnd = nameStartInCodeLine + fnLen;
                         if (nameEnd >= codeLine.Length)
                             skipLine = true;
@@ -799,6 +803,10 @@ public partial class GscIndexer(ILogger logger)
 
                 if (!hasBrace) continue;
 
+                var prefix = codeLine.AsSpan(0, prefixLength);
+                var isPrivate = HasModifierWord(prefix, "private");
+                var isAutoExec = HasModifierWord(prefix, "autoexec");
+
                 var docBlock = GscDocCommentParser.TryRenderBlockEndingAt(rawLines, i - 1);
                 if (docBlock != null)
                 {
@@ -809,6 +817,8 @@ public partial class GscIndexer(ILogger logger)
                         Parameters: paramsText,
                         Type: SymbolType.Function,
                         Documentation: docBlock,
+                        IsPrivate: isPrivate,
+                        IsAutoExec: isAutoExec,
                         DocumentationRendered: true
                     );
                 }
@@ -888,7 +898,9 @@ public partial class GscIndexer(ILogger logger)
                     LineNumber: i + 1,
                     Parameters: paramsText,
                     Type: SymbolType.Function,
-                    Documentation: doc
+                    Documentation: doc,
+                    IsPrivate: isPrivate,
+                    IsAutoExec: isAutoExec
                 );
             }
         }

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -42,7 +42,7 @@ public partial class GscIndexer(ILogger logger)
     private static readonly Lock _scanCacheLock = new();
 
     // local variable cache for GSC functions
-    public record LocalVariable(string Name, string Value, int Line);
+    public record LocalVariable(string Name, string Value, int Line, bool IsConst);
     private static readonly Dictionary<string, List<LocalVariable>> _localVarCache = [];
     private static readonly Lock _localVarCacheLock = new();
 
@@ -981,12 +981,24 @@ public partial class GscIndexer(ILogger logger)
                 if (GscLanguageKeywords.LocalVariableReservedWords.Contains(paramName)) continue;
 
                 if (paramNames.Add(paramName))
-                    result.Add(new LocalVariable(paramName, "parameter", funcDefLine + 1));
+                    result.Add(new LocalVariable(paramName, "parameter", funcDefLine + 1, IsConst: false));
             }
         }
 
         for (int i = braceStart; i <= funcEnd; i++)
         {
+            var constMatch = ConstVarAssignmentRegex().Match(lines[i]);
+            if (constMatch.Success)
+            {
+                string constName = constMatch.Groups[1].Value;
+                string constValue = constMatch.Groups[2].Value.Trim();
+
+                if (GscLanguageKeywords.LocalVariableReservedWords.Contains(constName)) continue;
+
+                result.Add(new LocalVariable(constName, constValue, i + 1, IsConst: true));
+                continue;
+            }
+
             var match = LocalVarAssignmentRegex().Match(lines[i]);
             if (!match.Success) continue;
 
@@ -995,7 +1007,7 @@ public partial class GscIndexer(ILogger logger)
 
             if (GscLanguageKeywords.LocalVariableReservedWords.Contains(name)) continue;
 
-            result.Add(new LocalVariable(name, value, i + 1));
+            result.Add(new LocalVariable(name, value, i + 1, IsConst: false));
         }
 
         return result;

--- a/GSCLSP.Core/Indexing/GscIndexer.cs
+++ b/GSCLSP.Core/Indexing/GscIndexer.cs
@@ -987,7 +987,8 @@ public partial class GscIndexer(ILogger logger)
 
         for (int i = braceStart; i <= funcEnd; i++)
         {
-            var constMatch = ConstVarAssignmentRegex().Match(lines[i]);
+            var codeLine = StripTrailingLineComment(lines[i]);
+            var constMatch = ConstVarAssignmentRegex().Match(codeLine);
             if (constMatch.Success)
             {
                 string constName = constMatch.Groups[1].Value;
@@ -999,7 +1000,7 @@ public partial class GscIndexer(ILogger logger)
                 continue;
             }
 
-            var match = LocalVarAssignmentRegex().Match(lines[i]);
+            var match = LocalVarAssignmentRegex().Match(codeLine);
             if (!match.Success) continue;
 
             string name = match.Groups[1].Value;

--- a/GSCLSP.Core/Models/GscLanguageKeywords.cs
+++ b/GSCLSP.Core/Models/GscLanguageKeywords.cs
@@ -14,7 +14,7 @@ public static class GscLanguageKeywords
         "true", "false", "undefined",
         "size", "game", "self", "anim", "level",
         "isdefined", "istrue",
-        "function", "private", "autoexec"
+        "function", "private", "autoexec", "const"
     };
 
     public static readonly HashSet<string> FunctionModifierKeywords = new(StringComparer.OrdinalIgnoreCase)
@@ -66,6 +66,6 @@ public static class GscLanguageKeywords
         "notify", "endon",
         "thread", "childthread", "thisthread", "call",
         "true", "false", "undefined",
-        "self", "level", "game", "anim"
+        "self", "level", "game", "anim", "const"
     };
 }

--- a/GSCLSP.Core/Models/GscSymbol.cs
+++ b/GSCLSP.Core/Models/GscSymbol.cs
@@ -13,5 +13,6 @@ public record GscSymbol(
     int? MaxArgs = null,
     bool IsVariadic = false,
     bool IsPrivate = false,
+    bool IsAutoExec = false,
     bool DocumentationRendered = false
 );

--- a/GSCLSP.Core/Models/RegexPatterns.cs
+++ b/GSCLSP.Core/Models/RegexPatterns.cs
@@ -23,7 +23,7 @@ public partial class RegexPatterns
     [GeneratedRegex(@"([\w\\]+)::$")]
     public static partial Regex NameSpaceRegex();
 
-    [GeneratedRegex(@"^(?:(?:(?:function|private|autoexec)\s+)*\s*)?(?<name>[a-zA-Z_]\w*)\s*\((?<params>[^)]*)\)", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^(?:(?:(?:function\s+)(?:private\s+)?(?:autoexec\s+)?|autoexec)\s*)?(?<name>[a-zA-Z_]\w*)\s*\((?<params>[^)]*)\)", RegexOptions.Multiline)]
     public static partial Regex FunctionMultiLineRegex();
 
     [GeneratedRegex(@"(Summary|Example|MandatoryArg|OptionalArg|Module|CallOn|SPMP):")]

--- a/GSCLSP.Core/Models/RegexPatterns.cs
+++ b/GSCLSP.Core/Models/RegexPatterns.cs
@@ -23,7 +23,7 @@ public partial class RegexPatterns
     [GeneratedRegex(@"([\w\\]+)::$")]
     public static partial Regex NameSpaceRegex();
 
-    [GeneratedRegex(@"^(?:(?:function\s+(?:private\s+)?(?:autoexec\s+)?)\s*)?(?<name>[a-zA-Z_]\w*)\s*\((?<params>[^)]*)\)", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^(?:(?:(?:function|private|autoexec)\s+)*\s*)?(?<name>[a-zA-Z_]\w*)\s*\((?<params>[^)]*)\)", RegexOptions.Multiline)]
     public static partial Regex FunctionMultiLineRegex();
 
     [GeneratedRegex(@"(Summary|Example|MandatoryArg|OptionalArg|Module|CallOn|SPMP):")]
@@ -52,6 +52,9 @@ public partial class RegexPatterns
 
     [GeneratedRegex(@"^\s+([a-zA-Z_]\w*)\s*=\s*(.+?)\s*;")]
     public static partial Regex LocalVarAssignmentRegex();
+
+    [GeneratedRegex(@"^\s*const\s+([a-zA-Z_]\w*)\s*=\s*(.+?)\s*;", RegexOptions.IgnoreCase)]
+    public static partial Regex ConstVarAssignmentRegex();
 
     [GeneratedRegex(@"^([A-Za-z_]\w*)\s*=\s*(.+?)\s*;")]
     public static partial Regex GlobalVarAssignmentRegex();

--- a/GSCLSP.Extension/README.md
+++ b/GSCLSP.Extension/README.md
@@ -54,6 +54,7 @@ When you hover your mouse cursor over any sort of function, macro, variable, or 
 - `gsclsp.missingAnimtree`: Sanity check #animtree for valid #using_animtree
 - `gsclsp.variableShadowsNamespace`: Variable named after a namespace the file uses (Treyarch games only)
 - `gsclsp.misleadingIndentation`: Misleading indentation warning
+- `gsclsp.constReassignment`: Const variable reassignment error
 
 ### Code Actions
 
@@ -141,6 +142,8 @@ Supported format:
 - `// gsclsp-disable: builtin-arg-count`
 - `// gsclsp-disable: variable-shadows-namespace`
 - `// gsclsp-disable: misleading-indentation`
+- `// gsclsp-disable: early-return`
+- `// gsclsp-disable: const-reassignment`
 - `// gsclsp-disable: recursive, semicolon, builtin-args`
 - `// gsclsp-disable: all`
 
@@ -151,6 +154,7 @@ Aliases are also supported:
 - `builtin-args` or `arity` -> `builtin-arg-count`
 - `namespace-shadow` or `shadowed-namespace` -> `variable-shadows-namespace`
 - `missing-braces` or `braces` -> `misleading-indentation`
+- `const` -> `const-reassignment`
 
 ## Command
 

--- a/GSCLSP.Extension/syntaxes/gsc.tmLanguage.json
+++ b/GSCLSP.Extension/syntaxes/gsc.tmLanguage.json
@@ -577,12 +577,17 @@
     "variables": {
       "patterns": [
         {
-          "comment": "Namespace path: maps\\mp\\gametypes\\_hud_util (backslash-delimited) - not a variable name",
-          "name": "variable.other.gsc",
+          "comment": "Namespace path (ex: maps\\mp\\gametypes\\_hud_util)",
+          "name": "entity.name.namespace.gsc",
           "match": "[A-Za-z_][A-Za-z_0-9]*(\\\\[A-Za-z_][A-Za-z_0-9]*)+"
         },
         {
-          "comment": "Variable name only - not after a dot (members like .glowAlpha stay neutral)",
+          "comment": "Bare namespace qualifier (hud_util)",
+          "name": "entity.name.namespace.gsc",
+          "match": "\\b[A-Za-z_][A-Za-z0-9_]*(?=\\s*::)"
+        },
+        {
+          "comment": "Variable name only",
           "name": "variable.other.constant.gsc",
           "match": "(?<!\\.)\\b[A-Za-z_][A-Za-z0-9_]*\\b"
         }

--- a/GSCLSP.Extension/syntaxes/gsc.tmLanguage.json
+++ b/GSCLSP.Extension/syntaxes/gsc.tmLanguage.json
@@ -478,11 +478,18 @@
     "keywords": {
       "patterns": [
         {
-          "name": "keyword.control.gsc",
-          "match": "\\b(break(point)?|case|continue|default|else|for|foreach|if|return|switch|thread|waittill|waittillmatch|waittillframeend|while|do|wait|endon|notify|function|private|autoexec)\\b"
+          "match": "\\b(const)\\s+([A-Za-z_]\\w*)",
+          "captures": {
+            "1": { "name": "storage.modifier.const.gsc" },
+            "2": { "name": "variable.other.constant.gsc" }
+          }
         },
         {
-          "name": "variable.language",
+          "name": "keyword.control.gsc",
+          "match": "\\b(break(point)?|case|continue|default|else|for|foreach|if|return|switch|thread|waittill|waittillmatch|waittillframeend|while|do|wait|endon|notify|function|private|autoexec|const)\\b"
+        },
+        {
+          "name": "constant.language.gsc",
           "match": "\\b(game|level|self)\\b"
         }
       ]
@@ -570,8 +577,14 @@
     "variables": {
       "patterns": [
         {
+          "comment": "Namespace path: maps\\mp\\gametypes\\_hud_util (backslash-delimited) - not a variable name",
           "name": "variable.other.gsc",
-          "match": "\\b[A-Za-z_][A-Za-z0-9_]*\\b"
+          "match": "[A-Za-z_][A-Za-z_0-9]*(\\\\[A-Za-z_][A-Za-z_0-9]*)+"
+        },
+        {
+          "comment": "Variable name only - not after a dot (members like .glowAlpha stay neutral)",
+          "name": "variable.other.constant.gsc",
+          "match": "(?<!\\.)\\b[A-Za-z_][A-Za-z0-9_]*\\b"
         }
       ]
     }

--- a/GSCLSP.Lexer/GscLexer.cs
+++ b/GSCLSP.Lexer/GscLexer.cs
@@ -7,7 +7,8 @@ public sealed class GscLexer
         "if", "else", "for", "foreach", "while", "switch", "return", "wait",
         "waittill", "waittillmatch", "waittillframeend", "notify", "endon",
         "thread", "childthread", "break", "continue", "case", "default",
-        "true", "false", "undefined", "self", "level", "game"
+        "true", "false", "undefined", "self", "level", "game",
+        "function", "private", "autoexec", "const"
     };
 
     private string _source = string.Empty;

--- a/GSCLSP.Server/Handlers/GscCompletionHandler.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionHandler.cs
@@ -414,18 +414,22 @@ namespace GSCLSP.Server.Handlers
                 new Position(position.Line, segmentStart),
                 position);
 
-            var folders = _indexer.GetAllIndexedFilePaths()
+            bool isJup = _indexer.CurrentGame.Equals("jup", StringComparison.Ordinal);
+            if (isJup && lastSlash < 0)
+                return false;
+
+            var candidatePaths = _indexer.GetAllIndexedFilePaths()
                 .Select(ToRelativeScriptPath)
                 .Where(p => p.EndsWith(".gsc", StringComparison.OrdinalIgnoreCase))
                 .Select(p => p.Replace("/", "\\"))
-                .Where(p => p.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                .Where(p => p.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+
+            var addedFolder = false;
+            foreach (var folder in candidatePaths
                 .Select(p => p[prefix.Length..])
                 .Where(p => p.Contains('\\'))
                 .Select(p => p[..p.IndexOf('\\')])
-                .Distinct(StringComparer.OrdinalIgnoreCase);
-
-            var addedFolder = false;
-            foreach (var folder in folders)
+                .Distinct(StringComparer.OrdinalIgnoreCase))
             {
                 completions.Add(new CompletionItem
                 {
@@ -441,8 +445,33 @@ namespace GSCLSP.Server.Handlers
                 addedFolder = true;
             }
 
+            var addedFile = false;
+            
+            // JUP has a edge case where legacy GSC paths *do* work, so this shows those
+            if (isJup)
+            {
+                foreach (var fileName in candidatePaths
+                    .Select(p => p[prefix.Length..])
+                    .Where(p => !p.Contains('\\'))
+                    .Select(p => p.EndsWith(".gsc", StringComparison.OrdinalIgnoreCase) ? p[..^4] : p)
+                    .Distinct(StringComparer.OrdinalIgnoreCase))
+                {
+                    completions.Add(new CompletionItem
+                    {
+                        Label = fileName,
+                        LabelDetails = new CompletionItemLabelDetails { Description = ".gsc" },
+                        Kind = CompletionItemKind.File,
+                        FilterText = fileName,
+                        SortText = "1_" + fileName,
+                        InsertTextFormat = InsertTextFormat.PlainText,
+                        TextEdit = new TextEditOrInsertReplaceEdit(new TextEdit { Range = segmentRange, NewText = fileName })
+                    });
+                    addedFile = true;
+                }
+            }
+
             // the return value only decides whether to stop the parent function early
-            return lastSlash >= 0 && addedFolder;
+            return lastSlash >= 0 && (addedFolder || addedFile);
 
             string ToRelativeScriptPath(string filePath)
             {

--- a/GSCLSP.Server/Handlers/GscCompletionItemFactory.cs
+++ b/GSCLSP.Server/Handlers/GscCompletionItemFactory.cs
@@ -103,7 +103,13 @@ internal static class GscCompletionItemFactory
     internal static string GetSignatureText(GscSymbol symbol, List<string>? parsedArgs = null)
     {
         var parameterDetail = GetParameterDetail(symbol, parsedArgs);
-        return $"{symbol.Name}{parameterDetail}";
+
+        List<string>? modifiers = null;
+        if (symbol.IsPrivate) (modifiers ??= []).Add("private");
+        if (symbol.IsAutoExec) (modifiers ??= []).Add("autoexec");
+
+        var prefix = modifiers is null ? string.Empty : $"{string.Join(' ', modifiers)} ";
+        return $"{prefix}{symbol.Name}{parameterDetail}";
     }
 
     internal static string GetParameterDetail(GscSymbol symbol, List<string>? parsedArgs = null)

--- a/GSCLSP.Server/Handlers/GscHoverHandler.cs
+++ b/GSCLSP.Server/Handlers/GscHoverHandler.cs
@@ -302,10 +302,10 @@ public partial class GscHoverHandler(GscIndexer indexer, GscDocumentStore docume
             var localVar = matching[0];
             var comment = GetDefinitionComment(lines, localVar.Line - 1);
 
-            contentValue = $"```gsc\n{localVar.Name} = {localVar.Value}\n```\n";
+            contentValue = $"```gsc\n{(localVar.IsConst ? "const " : "")}{localVar.Name} = {localVar.Value};\n```\n";
             if (!string.IsNullOrEmpty(comment))
                 contentValue += $"{comment}\n\n";
-            contentValue += $"---\n`Variable`\n\n**Line:** {localVar.Line}";
+            contentValue += $"---\n`{(localVar.IsConst ? "Constant" : "Variable")}`\n\n**Line:** {localVar.Line}";
             reassignments = [.. matching.Skip(1)];
         }
 


### PR DESCRIPTION
rough example 
<img width="910" height="527" alt="image" src="https://github.com/user-attachments/assets/6d79f03c-1ab6-405f-b160-c63d36c627c8" />

closes #79 #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `const` declarations, constant tracking, and reassignment diagnostics with mute support.
  * Hover information now distinguishes constants from mutable variables.
  * Added improved support for `private` and `autoexec` function modifiers.
  * Added JUP legacy path and `.gsc` file completions.

* **Style**
  * Improved syntax highlighting and case-insensitive keyword recognition for constants, modifiers, and namespace paths.

* **Documentation**
  * Documented how to disable constant-reassignment and early-return diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->